### PR TITLE
feat(minesweeper): Game screen UI (grid, reveal/flag, timer, difficulty)

### DIFF
--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.pekomon.minesweeper.ui.GameScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,13 +14,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            App()
+            GameScreen()
         }
     }
 }
 
 @Preview
 @Composable
-fun AppAndroidPreview() {
-    App()
+fun GameScreenAndroidPreview() {
+    GameScreen()
 }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
@@ -1,30 +1,11 @@
 package com.example.pekomon.minesweeper
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
+import com.example.pekomon.minesweeper.ui.GameScreen
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
 fun App() {
-    MaterialTheme {
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text("Hello Minesweeper!")
-        }
-    }
+    GameScreen()
 }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -1,0 +1,289 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.awaitPointerEventScope
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.pekomon.minesweeper.game.Board
+import com.example.pekomon.minesweeper.game.Cell
+import com.example.pekomon.minesweeper.game.CellState
+import com.example.pekomon.minesweeper.game.Difficulty
+import com.example.pekomon.minesweeper.game.GameApi
+import com.example.pekomon.minesweeper.game.GameStatus
+import kotlinx.coroutines.delay
+
+@Composable
+fun GameScreen(modifier: Modifier = Modifier) {
+    val api = remember { GameApi(Difficulty.EASY) }
+    var difficulty by remember { mutableStateOf(Difficulty.EASY) }
+    var board by remember { mutableStateOf(api.board) }
+    var elapsedSeconds by remember { mutableStateOf(0) }
+    var timerRunning by remember { mutableStateOf(false) }
+    var difficultyMenuExpanded by remember { mutableStateOf(false) }
+
+    fun refreshBoard() {
+        board = api.board
+    }
+
+    fun resetGame(newDifficulty: Difficulty = difficulty) {
+        api.reset(newDifficulty)
+        board = api.board
+        difficulty = newDifficulty
+        elapsedSeconds = 0
+        timerRunning = false
+    }
+
+    val statusEmoji = when (board.status) {
+        GameStatus.IN_PROGRESS -> "⏳"
+        GameStatus.WON -> "🏆"
+        GameStatus.LOST -> "💥"
+    }
+
+    LaunchedEffect(board.status, board.revealedCount) {
+        when {
+            board.status != GameStatus.IN_PROGRESS -> timerRunning = false
+            board.revealedCount == 0 -> {
+                elapsedSeconds = 0
+                timerRunning = false
+            }
+            else -> timerRunning = true
+        }
+    }
+
+    LaunchedEffect(timerRunning) {
+        while (timerRunning) {
+            delay(1000)
+            elapsedSeconds += 1
+        }
+    }
+
+    MaterialTheme {
+        Surface(modifier = modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(16.dp),
+            ) {
+                TopBar(
+                    difficulty = difficulty,
+                    onDifficultyClick = { difficultyMenuExpanded = true },
+                    difficultyMenuExpanded = difficultyMenuExpanded,
+                    onDifficultyDismiss = { difficultyMenuExpanded = false },
+                    onDifficultySelected = {
+                        difficultyMenuExpanded = false
+                        resetGame(it)
+                    },
+                    onReset = { resetGame(difficulty) },
+                    elapsedSeconds = elapsedSeconds,
+                    statusEmoji = statusEmoji,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                BoardView(
+                    board = board,
+                    onReveal = { x, y ->
+                        if (board.status == GameStatus.IN_PROGRESS) {
+                            api.onReveal(x, y)
+                            refreshBoard()
+                        }
+                    },
+                    onToggleFlag = { x, y ->
+                        if (board.status == GameStatus.IN_PROGRESS) {
+                            api.onToggleFlag(x, y)
+                            refreshBoard()
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f, fill = true),
+                    cellSpacing = 4.dp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TopBar(
+    difficulty: Difficulty,
+    onDifficultyClick: () -> Unit,
+    difficultyMenuExpanded: Boolean,
+    onDifficultyDismiss: () -> Unit,
+    onDifficultySelected: (Difficulty) -> Unit,
+    onReset: () -> Unit,
+    elapsedSeconds: Int,
+    statusEmoji: String,
+    modifier: Modifier = Modifier,
+) {
+    val difficulties = remember { Difficulty.values().toList() }
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box {
+            Button(onClick = onDifficultyClick) {
+                Text(text = difficulty.toDisplayName())
+            }
+            DropdownMenu(
+                expanded = difficultyMenuExpanded,
+                onDismissRequest = onDifficultyDismiss,
+            ) {
+                difficulties.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option.toDisplayName()) },
+                        onClick = { onDifficultySelected(option) },
+                    )
+                }
+            }
+        }
+
+        Text(text = "$statusEmoji ${elapsedSeconds}s")
+
+        Button(onClick = onReset) {
+            Text(text = "Reset")
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun BoardView(
+    board: Board,
+    onReveal: (Int, Int) -> Unit,
+    onToggleFlag: (Int, Int) -> Unit,
+    modifier: Modifier = Modifier,
+    cellSpacing: Dp = 2.dp,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(board.width),
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(cellSpacing),
+        horizontalArrangement = Arrangement.spacedBy(cellSpacing),
+    ) {
+        items(board.cells, key = { it.y * board.width + it.x }) { cell ->
+            CellView(
+                cell = cell,
+                onReveal = { onReveal(cell.x, cell.y) },
+                onToggleFlag = { onToggleFlag(cell.x, cell.y) },
+                boardStatus = board.status,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun CellView(
+    cell: Cell,
+    onReveal: () -> Unit,
+    onToggleFlag: () -> Unit,
+    boardStatus: GameStatus,
+    modifier: Modifier = Modifier,
+) {
+    val cornerRadius = 6.dp
+    val updatedReveal by rememberUpdatedState(onReveal)
+    val updatedToggle by rememberUpdatedState(onToggleFlag)
+    val backgroundColor = when (cell.state) {
+        CellState.HIDDEN -> HiddenCellColor
+        CellState.REVEALED -> RevealedCellColor
+        CellState.FLAGGED -> FlaggedCellColor
+    }
+    val textColor = when {
+        cell.state == CellState.REVEALED && cell.isMine -> MaterialTheme.colorScheme.error
+        cell.state == CellState.REVEALED && cell.adjacentMines > 0 -> numberColor(cell.adjacentMines)
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+    val content = when {
+        cell.state == CellState.FLAGGED -> "🚩"
+        cell.state == CellState.REVEALED && cell.isMine -> "💣"
+        cell.state == CellState.REVEALED && cell.adjacentMines > 0 -> cell.adjacentMines.toString()
+        else -> ""
+    }
+    val revealEnabled = boardStatus == GameStatus.IN_PROGRESS && cell.state == CellState.HIDDEN
+
+    Box(
+        modifier = modifier
+            .aspectRatio(1f)
+            .background(backgroundColor, RoundedCornerShape(cornerRadius))
+            .border(1.dp, CellBorderColor, RoundedCornerShape(cornerRadius))
+            .pointerInput(boardStatus, cell.state) {
+                detectTapGestures(
+                    onTap = {
+                        if (revealEnabled) {
+                            updatedReveal()
+                        }
+                    },
+                    onLongPress = {
+                        if (cell.state != CellState.REVEALED) {
+                            updatedToggle()
+                        }
+                    },
+                )
+            }
+            .pointerInput(boardStatus, cell.state) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        if (event.type == PointerEventType.Press && event.buttons.isSecondaryPressed) {
+                            if (cell.state != CellState.REVEALED) {
+                                updatedToggle()
+                            }
+                        }
+                    }
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        if (content.isNotEmpty()) {
+            Text(
+                text = content,
+                color = textColor,
+                fontWeight = if (cell.state == CellState.REVEALED && cell.adjacentMines > 0) FontWeight.Bold else FontWeight.Normal,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+private fun Difficulty.toDisplayName(): String {
+    val name = name.lowercase()
+    return name.replaceFirstChar { it.titlecase() }
+}

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ThemeExt.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ThemeExt.kt
@@ -1,0 +1,21 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.ui.graphics.Color
+
+internal val HiddenCellColor = Color(0xFFB0BEC5)
+internal val RevealedCellColor = Color(0xFFF5F5F5)
+internal val FlaggedCellColor = Color(0xFFFFF59D)
+internal val CellBorderColor = Color(0xFF90A4AE)
+
+private val numberPalette = mapOf(
+    1 to Color(0xFF1976D2),
+    2 to Color(0xFF388E3C),
+    3 to Color(0xFFD32F2F),
+    4 to Color(0xFF512DA8),
+    5 to Color(0xFFF57C00),
+    6 to Color(0xFF00796B),
+    7 to Color(0xFF455A64),
+    8 to Color(0xFF795548),
+)
+
+internal fun numberColor(count: Int): Color = numberPalette[count] ?: Color(0xFF263238)

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/MainViewController.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/MainViewController.kt
@@ -3,5 +3,6 @@
 package com.example.pekomon.minesweeper
 
 import androidx.compose.ui.window.ComposeUIViewController
+import com.example.pekomon.minesweeper.ui.GameScreen
 
-fun MainViewController() = ComposeUIViewController { App() }
+fun MainViewController() = ComposeUIViewController { GameScreen() }

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/main.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/main.kt
@@ -3,12 +3,13 @@ package com.example.pekomon.minesweeper
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import com.example.pekomon.minesweeper.ui.GameScreen
 
 fun main() = application {
     Window(
         onCloseRequest = ::exitApplication,
         title = "Minesweeper",
     ) {
-        App()
+        GameScreen()
     }
 }

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/main.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/main.kt
@@ -2,11 +2,12 @@ package com.example.pekomon.minesweeper
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
+import com.example.pekomon.minesweeper.ui.GameScreen
 import kotlinx.browser.document
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     ComposeViewport(document.body!!) {
-        App()
+        GameScreen()
     }
 }


### PR DESCRIPTION
## Summary
- add a Minesweeper GameScreen with difficulty picker, timer, and interactive grid
- provide shared color helpers for cells and numbers
- use the new GameScreen across Android, Desktop, iOS, and Wasm entry points

## Testing
- ./gradlew spotlessApply spotlessCheck detekt test koverHtmlReport *(fails: 403 retrieving ktlint-cli from Maven Central)*

Closes #8
fixes #8

------
https://chatgpt.com/codex/tasks/task_b_68cace694c58832fb0736b9bfb254381