### PR TITLE
feat(minesweeper): runtime-only history (top-10 per difficulty)

### DIFF
--- a/Minesweeper/README.md
+++ b/Minesweeper/README.md
@@ -4,6 +4,7 @@
 
 A tiny Minesweeper built with Kotlin Multiplatform + Compose Multiplatform.
 Core game logic is implemented as pure Kotlin shared across all targets.
+- Runtime-only history of top-10 completion times per difficulty (cleared on app restart). Persistence will land in Phase 2.
 - Material 3 theming with coordinated light and dark palettes. Android 12+ devices automatically adopt dynamic color.
 - Custom splash screens and launcher icons across Android, iOS, Desktop and Web. Phase 1 ships text-only assets so the diff stays
   binary-free; branded bitmaps land in Phase 2.

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/history/HistoryModels.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/history/HistoryModels.kt
@@ -1,0 +1,9 @@
+package com.example.pekomon.minesweeper.history
+
+import com.example.pekomon.minesweeper.game.Difficulty
+
+data class RunRecord(
+    val difficulty: Difficulty,
+    val elapsedMillis: Long,
+    val epochMillis: Long,
+)

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/history/InMemoryHistoryStore.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/history/InMemoryHistoryStore.kt
@@ -1,0 +1,31 @@
+package com.example.pekomon.minesweeper.history
+
+import com.example.pekomon.minesweeper.game.Difficulty
+
+private const val MAX_RECORDS = 10
+
+object InMemoryHistoryStore {
+    private val records: MutableMap<Difficulty, MutableList<RunRecord>> =
+        Difficulty.values().associateWith { mutableListOf<RunRecord>() }.toMutableMap()
+
+    fun add(record: RunRecord) {
+        val bucket = records.getOrPut(record.difficulty) { mutableListOf() }
+        bucket.add(record)
+        bucket.sortWith(compareBy<RunRecord> { it.elapsedMillis }.thenBy { it.epochMillis })
+        if (bucket.size > MAX_RECORDS) {
+            bucket.subList(MAX_RECORDS, bucket.size).clear()
+        }
+    }
+
+    fun top(difficulty: Difficulty, limit: Int = MAX_RECORDS): List<RunRecord> {
+        if (limit <= 0) {
+            return emptyList()
+        }
+        val bucket = records[difficulty].orEmpty()
+        return bucket.take(limit)
+    }
+
+    internal fun clear() {
+        records.values.forEach { it.clear() }
+    }
+}

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -43,12 +44,15 @@ import com.example.pekomon.minesweeper.game.CellState
 import com.example.pekomon.minesweeper.game.Difficulty
 import com.example.pekomon.minesweeper.game.GameApi
 import com.example.pekomon.minesweeper.game.GameStatus
+import com.example.pekomon.minesweeper.history.InMemoryHistoryStore
+import com.example.pekomon.minesweeper.history.RunRecord
 import com.example.pekomon.minesweeper.ui.theme.cellBorderColor
 import com.example.pekomon.minesweeper.ui.theme.flaggedCellColor
 import com.example.pekomon.minesweeper.ui.theme.hiddenCellColor
 import com.example.pekomon.minesweeper.ui.theme.numberColor
 import com.example.pekomon.minesweeper.ui.theme.revealedCellColor
 import kotlinx.coroutines.delay
+import kotlin.system.getTimeMillis
 
 @Composable
 fun GameScreen(modifier: Modifier = Modifier) {
@@ -58,6 +62,8 @@ fun GameScreen(modifier: Modifier = Modifier) {
     var elapsedSeconds by remember { mutableStateOf(0) }
     var timerRunning by remember { mutableStateOf(false) }
     var difficultyMenuExpanded by remember { mutableStateOf(false) }
+    var showHistoryDialog by remember { mutableStateOf(false) }
+    var historyVersion by remember { mutableStateOf(0) }
 
     fun refreshBoard() {
         board = api.board
@@ -95,6 +101,20 @@ fun GameScreen(modifier: Modifier = Modifier) {
         }
     }
 
+    LaunchedEffect(board.status) {
+        if (board.status == GameStatus.WON) {
+            val elapsedMillis = elapsedSeconds * 1000L
+            InMemoryHistoryStore.add(
+                RunRecord(
+                    difficulty = difficulty,
+                    elapsedMillis = elapsedMillis,
+                    epochMillis = getTimeMillis(),
+                ),
+            )
+            historyVersion += 1
+        }
+    }
+
     Surface(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
@@ -113,6 +133,7 @@ fun GameScreen(modifier: Modifier = Modifier) {
                 onReset = { resetGame(difficulty) },
                 elapsedSeconds = elapsedSeconds,
                 statusEmoji = statusEmoji,
+                onHistoryClick = { showHistoryDialog = true },
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -138,6 +159,15 @@ fun GameScreen(modifier: Modifier = Modifier) {
             )
         }
     }
+
+    if (showHistoryDialog) {
+        key(historyVersion) {
+            HistoryDialog(
+                currentDifficulty = difficulty,
+                onClose = { showHistoryDialog = false },
+            )
+        }
+    }
 }
 
 @Composable
@@ -150,6 +180,7 @@ private fun TopBar(
     onReset: () -> Unit,
     elapsedSeconds: Int,
     statusEmoji: String,
+    onHistoryClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val difficulties = remember { Difficulty.values().toList() }
@@ -177,8 +208,17 @@ private fun TopBar(
 
         Text(text = "$statusEmoji ${elapsedSeconds}s")
 
-        Button(onClick = onReset) {
-            Text(text = "Reset")
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(onClick = onHistoryClick) {
+                Text(text = "History")
+            }
+
+            Button(onClick = onReset) {
+                Text(text = "Reset")
+            }
         }
     }
 }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/HistoryDialog.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/HistoryDialog.kt
@@ -1,0 +1,202 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedFilterChip
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.pekomon.minesweeper.game.Difficulty
+import com.example.pekomon.minesweeper.history.InMemoryHistoryStore
+import com.example.pekomon.minesweeper.history.RunRecord
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HistoryDialog(
+    currentDifficulty: Difficulty,
+    onClose: () -> Unit,
+) {
+    var selectedDifficulty by remember { mutableStateOf(currentDifficulty) }
+    val difficulties = remember { Difficulty.values().toList() }
+    val records = InMemoryHistoryStore.top(selectedDifficulty)
+
+    AlertDialog(
+        onDismissRequest = onClose,
+        confirmButton = {
+            TextButton(onClick = onClose) {
+                Text(text = "Close")
+            }
+        },
+        title = { Text(text = "History") },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    difficulties.forEach { difficulty ->
+                        ElevatedFilterChip(
+                            selected = selectedDifficulty == difficulty,
+                            onClick = { selectedDifficulty = difficulty },
+                            label = { Text(text = difficulty.toDisplayName()) },
+                            colors = ButtonDefaults.elevatedFilterChipColors(),
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                if (records.isEmpty()) {
+                    Text(
+                        text = "No wins recorded for ${selectedDifficulty.toDisplayName()} yet.",
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                } else {
+                    HistoryList(records = records)
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun HistoryList(records: List<RunRecord>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = (ROW_HEIGHT * records.size).coerceAtMost(ROW_HEIGHT * MAX_VISIBLE_ROWS))
+            .padding(top = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        itemsIndexed(records) { index, record ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(text = "${index + 1}.")
+                    Text(text = formatElapsed(record.elapsedMillis))
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Text(
+                    text = formatTimestamp(record.epochMillis),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+
+private fun formatElapsed(elapsedMillis: Long): String {
+    val totalSeconds = (elapsedMillis / 1000).coerceAtLeast(0L)
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    val minutePart = minutes.toString().padStart(2, '0')
+    val secondPart = seconds.toString().padStart(2, '0')
+    return "$minutePart:$secondPart"
+}
+
+private fun formatTimestamp(epochMillis: Long): String {
+    val parts = epochMillis.toUtcParts()
+    return buildString {
+        append(parts.year.toString().padStart(4, '0'))
+        append('-')
+        append(parts.month.toString().padStart(2, '0'))
+        append('-')
+        append(parts.day.toString().padStart(2, '0'))
+        append(' ')
+        append(parts.hour.toString().padStart(2, '0'))
+        append(':')
+        append(parts.minute.toString().padStart(2, '0'))
+    }
+}
+
+private data class UtcDateTimeParts(
+    val year: Int,
+    val month: Int,
+    val day: Int,
+    val hour: Int,
+    val minute: Int,
+)
+
+private fun Long.toUtcParts(): UtcDateTimeParts {
+    val epochSecond = floorDiv(this, MILLIS_PER_SECOND)
+    val epochDay = floorDiv(epochSecond, SECONDS_PER_DAY)
+    val secondsOfDay = floorMod(epochSecond, SECONDS_PER_DAY).toInt()
+    val hour = secondsOfDay / SECONDS_PER_HOUR
+    val minute = (secondsOfDay % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+    val (year, month, day) = epochDayToDate(epochDay)
+    return UtcDateTimeParts(year = year, month = month, day = day, hour = hour, minute = minute)
+}
+
+private fun epochDayToDate(epochDay: Long): Triple<Int, Int, Int> {
+    var zeroDay = epochDay + DAYS_0000_TO_1970 - 60
+    var adjust: Long = 0
+    if (zeroDay < 0) {
+        val adjustCycles = (zeroDay + 1) / DAYS_PER_CYCLE - 1
+        adjust = adjustCycles * 400
+        zeroDay -= adjustCycles * DAYS_PER_CYCLE
+    }
+    var yearEst = (400 * zeroDay + 591) / DAYS_PER_CYCLE
+    var doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400)
+    if (doyEst < 0) {
+        yearEst -= 1
+        doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400)
+    }
+    val marchDoy0 = doyEst.toInt()
+    val marchMonth0 = (marchDoy0 * 5 + 2) / 153
+    val month = (marchMonth0 + 2) % 12 + 1
+    val day = marchDoy0 - (marchMonth0 * 153 + 2) / 5 + 1
+    val year = (yearEst + adjust + marchMonth0 / 10).toInt()
+    return Triple(year, month, day)
+}
+
+private fun floorDiv(x: Long, y: Long): Long {
+    var result = x / y
+    if ((x xor y) < 0 && x % y != 0L) {
+        result -= 1
+    }
+    return result
+}
+
+private fun floorMod(x: Long, y: Long): Long = x - floorDiv(x, y) * y
+
+private const val MILLIS_PER_SECOND = 1000L
+private const val SECONDS_PER_MINUTE = 60L
+private const val SECONDS_PER_HOUR = SECONDS_PER_MINUTE * 60
+private const val SECONDS_PER_DAY = SECONDS_PER_HOUR * 24
+private const val DAYS_PER_CYCLE = 146097L
+private const val DAYS_0000_TO_1970 = 719528L
+
+private val ROW_HEIGHT = 32.dp
+private const val MAX_VISIBLE_ROWS = 10
+
+private fun Difficulty.toDisplayName(): String {
+    val name = name.lowercase()
+    return name.replaceFirstChar { it.titlecase() }
+}

--- a/Minesweeper/composeApp/src/commonTest/kotlin/com/example/pekomon/minesweeper/history/InMemoryHistoryStoreTest.kt
+++ b/Minesweeper/composeApp/src/commonTest/kotlin/com/example/pekomon/minesweeper/history/InMemoryHistoryStoreTest.kt
@@ -1,0 +1,63 @@
+package com.example.pekomon.minesweeper.history
+
+import com.example.pekomon.minesweeper.game.Difficulty
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InMemoryHistoryStoreTest {
+    @BeforeTest
+    fun setup() {
+        InMemoryHistoryStore.clear()
+    }
+
+    @Test
+    fun `adding more than ten records keeps only top ten`() {
+        repeat(15) { index ->
+            InMemoryHistoryStore.add(
+                RunRecord(
+                    difficulty = Difficulty.EASY,
+                    elapsedMillis = (15 - index).toLong() * 1000L,
+                    epochMillis = index.toLong(),
+                ),
+            )
+        }
+
+        val records = InMemoryHistoryStore.top(Difficulty.EASY)
+
+        assertEquals(10, records.size)
+        assertTrue(records.all { it.difficulty == Difficulty.EASY })
+        assertEquals((1L..10L).map { it * 1000L }, records.map { it.elapsedMillis })
+    }
+
+    @Test
+    fun `records are returned in ascending order of elapsed time`() {
+        listOf(5000L, 1000L, 3000L, 2000L).forEachIndexed { index, duration ->
+            InMemoryHistoryStore.add(
+                RunRecord(
+                    difficulty = Difficulty.MEDIUM,
+                    elapsedMillis = duration,
+                    epochMillis = index.toLong(),
+                ),
+            )
+        }
+
+        val records = InMemoryHistoryStore.top(Difficulty.MEDIUM)
+
+        assertEquals(listOf(1000L, 2000L, 3000L, 5000L), records.map { it.elapsedMillis })
+    }
+
+    @Test
+    fun `records are filtered per difficulty`() {
+        val easyRecord = RunRecord(Difficulty.EASY, elapsedMillis = 1000L, epochMillis = 1)
+        val hardRecord = RunRecord(Difficulty.HARD, elapsedMillis = 2000L, epochMillis = 2)
+
+        InMemoryHistoryStore.add(easyRecord)
+        InMemoryHistoryStore.add(hardRecord)
+
+        assertEquals(listOf(easyRecord), InMemoryHistoryStore.top(Difficulty.EASY))
+        assertEquals(listOf(hardRecord), InMemoryHistoryStore.top(Difficulty.HARD))
+        assertTrue(InMemoryHistoryStore.top(Difficulty.MEDIUM).isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared RunRecord model and in-memory store to keep the fastest 10 finishes per difficulty
- record wins from the game screen, surface a history dialog with per-difficulty tabs, and format elapsed/timestamp data
- cover the store with common tests and document the runtime-only nature of the new history

## Testing
- ./gradlew spotlessApply spotlessCheck detekt test koverHtmlReport *(fails: unable to download ktlint-cli 1.3.1 – 403 Forbidden from repo.maven.apache.org)*

Closes #5
fixes #5

------
https://chatgpt.com/codex/tasks/task_b_68cdb4406d20832f96109dd7442f28c1