### PR TITLE
ui: split CellView into smaller composables and remove complexity suppressions

### DIFF
--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContainer.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContainer.kt
@@ -1,0 +1,35 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.pekomon.minesweeper.ui.theme.cellBorderColor
+
+@Composable
+internal fun CellContainer(
+    backgroundColor: Color,
+    cornerRadius: Dp,
+    modifier: Modifier = Modifier,
+    interactionModifier: Modifier = Modifier,
+    contentAlignment: Alignment = Alignment.Center,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val shape = RoundedCornerShape(cornerRadius)
+    Box(
+        modifier =
+            modifier
+                .background(backgroundColor, shape)
+                .border(1.dp, cellBorderColor(), shape)
+                .then(interactionModifier),
+        contentAlignment = contentAlignment,
+        content = content,
+    )
+}

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContent.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContent.kt
@@ -1,0 +1,58 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.example.pekomon.minesweeper.game.CellState
+import com.example.pekomon.minesweeper.ui.theme.numberColor
+
+@Composable
+internal fun CellContent(
+    state: CellState,
+    isMine: Boolean,
+    adjacentMines: Int,
+    modifier: Modifier = Modifier,
+) {
+    val content = cellContent(state, isMine, adjacentMines)
+    if (content.isEmpty()) {
+        return
+    }
+
+    Text(
+        text = content,
+        color = cellContentColor(state, isMine, adjacentMines),
+        fontWeight =
+            if (state == CellState.REVEALED && adjacentMines > 0) {
+                FontWeight.Bold
+            } else {
+                FontWeight.Normal
+            },
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = modifier,
+    )
+}
+
+private fun cellContent(
+    state: CellState,
+    isMine: Boolean,
+    adjacentMines: Int,
+): String =
+    when {
+        state == CellState.FLAGGED -> "🚩"
+        state == CellState.REVEALED && isMine -> "💣"
+        state == CellState.REVEALED && adjacentMines > 0 -> adjacentMines.toString()
+        else -> ""
+    }
+
+private fun cellContentColor(
+    state: CellState,
+    isMine: Boolean,
+    adjacentMines: Int,
+) =
+    when {
+        state == CellState.REVEALED && isMine -> MaterialTheme.colorScheme.error
+        state == CellState.REVEALED && adjacentMines > 0 -> numberColor(adjacentMines)
+        else -> MaterialTheme.colorScheme.onSurface
+    }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellInteractions.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellInteractions.kt
@@ -1,0 +1,36 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.input.pointer.pointerInput
+
+@OptIn(ExperimentalFoundationApi::class)
+internal fun Modifier.cellInteractions(
+    revealEnabled: Boolean,
+    toggleEnabled: Boolean,
+    onReveal: () -> Unit,
+    onToggleFlag: () -> Unit,
+): Modifier =
+    composed {
+        val currentReveal by rememberUpdatedState(onReveal)
+        val currentToggle by rememberUpdatedState(onToggleFlag)
+
+        pointerInput(revealEnabled, toggleEnabled) {
+            detectTapGestures(
+                onTap = {
+                    if (revealEnabled) {
+                        currentReveal()
+                    }
+                },
+                onLongPress = {
+                    if (toggleEnabled) {
+                        currentToggle()
+                    }
+                },
+            )
+        }
+    }


### PR DESCRIPTION
## Summary
- move layout and styling responsibilities into a reusable `CellContainer` composable
- extract glyph/text rendering into `CellContent` and pointer handling into `Modifier.cellInteractions`
- keep `CellView` as a thin coordinator over the new pieces so the board UI remains unchanged

Behavior and visuals remain unchanged.

Closes #21
fixes #21

## Verification
- [ ] Android: ./gradlew :composeApp:assembleDebug *(fails: Android SDK unavailable in container)*
- [ ] Desktop: ./gradlew :composeApp:packageReleaseUberJarForCurrentOS *(fails: Maven Central returned HTTP 403 in container)*
- [ ] WASM: ./gradlew :composeApp:wasmJsBrowserDistribution *(fails: Maven Central returned HTTP 403 in container)*
- [ ] Quality: ./gradlew :composeApp:spotlessCheck :composeApp:detekt :composeApp:test *(fails: Maven Central HTTP 403 and missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d1686f797c832fbe11eaad414dc284