### PR TITLE
Persist selected difficulty across launches (KMP)

### DIFF
--- a/Minesweeper/README.md
+++ b/Minesweeper/README.md
@@ -7,6 +7,7 @@ Minesweeper is built with Compose Multiplatform to target Android, iOS, Desktop,
 
 ## Features (Phase 1)
 - Difficulty selection: Easy, Medium, and Hard boards.
+- Selected difficulty is remembered across launches on all platforms.
 - Runtime-only history of the top 10 completion times per difficulty.
 - Material 3 design system with coordinated light and dark themes.
 - Binary-free splash experience powered by vector and storyboard assets.

--- a/Minesweeper/composeApp/build.gradle.kts
+++ b/Minesweeper/composeApp/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.core.splashscreen)
                 implementation(libs.androidx.lifecycle.runtimeKtx)
+                implementation(libs.androidx.datastore.preferences)
                 implementation(libs.material)
             }
         }

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
+import com.example.pekomon.minesweeper.settings.initializeSettingsRepository
+import com.example.pekomon.minesweeper.MinesweeperContent
 import com.example.pekomon.minesweeper.ui.GameScreen
 import com.example.pekomon.minesweeper.ui.theme.AndroidMinesweeperTheme
 import kotlinx.coroutines.delay
@@ -37,6 +39,8 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
+        initializeSettingsRepository(applicationContext)
+
         splashScreen?.let { screen ->
             var keepSplashVisible = true
             screen.setKeepOnScreenCondition { keepSplashVisible }
@@ -49,7 +53,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             AndroidMinesweeperTheme {
                 LegacySplashHost(showLegacySplash = !supportsSystemSplash) {
-                    GameScreen()
+                    MinesweeperContent()
                 }
             }
         }

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import com.example.pekomon.minesweeper.settings.initializeSettingsRepository
-import com.example.pekomon.minesweeper.MinesweeperContent
 import com.example.pekomon.minesweeper.ui.GameScreen
 import com.example.pekomon.minesweeper.ui.theme.AndroidMinesweeperTheme
 import kotlinx.coroutines.delay

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
@@ -1,0 +1,51 @@
+package com.example.pekomon.minesweeper.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.example.pekomon.minesweeper.game.Difficulty
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+private val Context.dataStore by preferencesDataStore(name = "minesweeper_settings")
+
+private class AndroidSettingsRepository(
+    private val context: Context,
+) : SettingsRepository {
+    private val difficultyKey = stringPreferencesKey(SettingsKeys.SELECTED_DIFFICULTY)
+
+    override fun getSelectedDifficulty(): Difficulty? =
+        runBlocking {
+            val stored = context.dataStore.data.first()[difficultyKey]
+            stored?.let { runCatching { Difficulty.valueOf(it) }.getOrNull() }
+        }
+
+    override fun setSelectedDifficulty(value: Difficulty) {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                preferences[difficultyKey] = value.name
+            }
+        }
+    }
+}
+
+private object AndroidSettingsHolder {
+    @Volatile
+    private var repository: SettingsRepository? = null
+
+    fun initialize(context: Context) {
+        if (repository == null) {
+            repository = AndroidSettingsRepository(context.applicationContext)
+        }
+    }
+
+    fun repository(): SettingsRepository =
+        repository ?: error("SettingsRepository not initialized. Call initializeSettingsRepository(context) first.")
+}
+
+fun initializeSettingsRepository(context: Context) {
+    AndroidSettingsHolder.initialize(context)
+}
+
+actual fun provideSettingsRepository(): SettingsRepository = AndroidSettingsHolder.repository()

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
@@ -1,6 +1,13 @@
 package com.example.pekomon.minesweeper
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.example.pekomon.minesweeper.game.Difficulty
+import com.example.pekomon.minesweeper.settings.SettingsRepository
+import com.example.pekomon.minesweeper.settings.provideSettingsRepository
 import com.example.pekomon.minesweeper.ui.GameScreen
 import com.example.pekomon.minesweeper.ui.theme.MinesweeperTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -9,6 +16,34 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App() {
     MinesweeperTheme(useDarkTheme = false) {
-        GameScreen()
+        MinesweeperContent()
+    }
+}
+
+@Composable
+fun MinesweeperContent() {
+    val settingsRepository =
+        remember {
+            runCatching { provideSettingsRepository() }.getOrElse { InMemorySettingsRepository() }
+        }
+    var storedDifficulty by remember { mutableStateOf(settingsRepository.getSelectedDifficulty()) }
+    val initialDifficulty = storedDifficulty ?: Difficulty.EASY
+
+    GameScreen(
+        initialDifficulty = initialDifficulty,
+        onDifficultyChanged = {
+            storedDifficulty = it
+            settingsRepository.setSelectedDifficulty(it)
+        },
+    )
+}
+
+private class InMemorySettingsRepository : SettingsRepository {
+    private var difficulty: Difficulty? = null
+
+    override fun getSelectedDifficulty(): Difficulty? = difficulty
+
+    override fun setSelectedDifficulty(value: Difficulty) {
+        difficulty = value
     }
 }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
@@ -1,0 +1,19 @@
+package com.example.pekomon.minesweeper.settings
+
+import com.example.pekomon.minesweeper.game.Difficulty
+
+/**
+ * Stores small app preferences. Currently only selected difficulty.
+ * Synchronous and simple by design for this app.
+ */
+interface SettingsRepository {
+    fun getSelectedDifficulty(): Difficulty? // null = not set
+    fun setSelectedDifficulty(value: Difficulty)
+}
+
+object SettingsKeys {
+    const val SELECTED_DIFFICULTY = "selected_difficulty"
+}
+
+/** Expect a platform-specific provider so common UI can obtain the repo. */
+expect fun provideSettingsRepository(): SettingsRepository

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
@@ -8,6 +8,7 @@ import com.example.pekomon.minesweeper.game.Difficulty
  */
 interface SettingsRepository {
     fun getSelectedDifficulty(): Difficulty? // null = not set
+
     fun setSelectedDifficulty(value: Difficulty)
 }
 

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -71,9 +71,13 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun GameScreen(modifier: Modifier = Modifier) {
-    val api = remember { GameApi(Difficulty.EASY) }
-    var difficulty by remember { mutableStateOf(Difficulty.EASY) }
+fun GameScreen(
+    modifier: Modifier = Modifier,
+    initialDifficulty: Difficulty = Difficulty.EASY,
+    onDifficultyChanged: (Difficulty) -> Unit = {},
+) {
+    val api = remember { GameApi(initialDifficulty) }
+    var difficulty by remember { mutableStateOf(initialDifficulty) }
     var board by remember { mutableStateOf(api.board) }
     var elapsedSeconds by remember { mutableStateOf(0) }
     var timerRunning by remember { mutableStateOf(false) }
@@ -151,6 +155,7 @@ fun GameScreen(modifier: Modifier = Modifier) {
                     onDifficultySelected = {
                         difficultyMenuExpanded = false
                         resetGame(it)
+                        onDifficultyChanged(it)
                     },
                     onReset = { resetGame(difficulty) },
                     elapsedSeconds = elapsedSeconds,

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/MainViewController.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/MainViewController.kt
@@ -3,7 +3,6 @@
 package com.example.pekomon.minesweeper
 
 import androidx.compose.ui.window.ComposeUIViewController
-import com.example.pekomon.minesweeper.MinesweeperContent
 import com.example.pekomon.minesweeper.ui.theme.MinesweeperTheme
 
 fun MainViewController() =

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/MainViewController.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/MainViewController.kt
@@ -3,12 +3,12 @@
 package com.example.pekomon.minesweeper
 
 import androidx.compose.ui.window.ComposeUIViewController
-import com.example.pekomon.minesweeper.ui.GameScreen
+import com.example.pekomon.minesweeper.MinesweeperContent
 import com.example.pekomon.minesweeper.ui.theme.MinesweeperTheme
 
 fun MainViewController() =
     ComposeUIViewController {
         MinesweeperTheme(useDarkTheme = false) {
-            GameScreen()
+            MinesweeperContent()
         }
     }

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
@@ -1,0 +1,21 @@
+package com.example.pekomon.minesweeper.settings
+
+import com.example.pekomon.minesweeper.game.Difficulty
+import platform.Foundation.NSUserDefaults
+
+private class IosSettingsRepository : SettingsRepository {
+    private val defaults = NSUserDefaults.standardUserDefaults
+
+    override fun getSelectedDifficulty(): Difficulty? {
+        val stored = defaults.stringForKey(SettingsKeys.SELECTED_DIFFICULTY) ?: return null
+        return runCatching { Difficulty.valueOf(stored) }.getOrNull()
+    }
+
+    override fun setSelectedDifficulty(value: Difficulty) {
+        defaults.setObject(value.name, forKey = SettingsKeys.SELECTED_DIFFICULTY)
+    }
+}
+
+private val repository: SettingsRepository by lazy { IosSettingsRepository() }
+
+actual fun provideSettingsRepository(): SettingsRepository = repository

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/main.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/main.kt
@@ -3,7 +3,7 @@ package com.example.pekomon.minesweeper
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import com.example.pekomon.minesweeper.ui.GameScreen
+import com.example.pekomon.minesweeper.MinesweeperContent
 import com.example.pekomon.minesweeper.ui.theme.MinesweeperTheme
 
 fun main() = application {
@@ -12,7 +12,7 @@ fun main() = application {
         title = "Minesweeper",
     ) {
         MinesweeperTheme(useDarkTheme = false) {
-            GameScreen()
+            MinesweeperContent()
         }
     }
 }

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
@@ -1,0 +1,24 @@
+package com.example.pekomon.minesweeper.settings
+
+import com.example.pekomon.minesweeper.game.Difficulty
+import java.util.prefs.Preferences
+
+internal class JvmSettingsRepository(
+    private val preferences: Preferences,
+) : SettingsRepository {
+    override fun getSelectedDifficulty(): Difficulty? {
+        val stored = preferences.get(SettingsKeys.SELECTED_DIFFICULTY, null) ?: return null
+        return runCatching { Difficulty.valueOf(stored) }.getOrNull()
+    }
+
+    override fun setSelectedDifficulty(value: Difficulty) {
+        preferences.put(SettingsKeys.SELECTED_DIFFICULTY, value.name)
+    }
+}
+
+private val repository: SettingsRepository by lazy {
+    val node = Preferences.userRoot().node("minesweeper")
+    JvmSettingsRepository(node)
+}
+
+actual fun provideSettingsRepository(): SettingsRepository = repository

--- a/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/JvmSettingsRepositoryTest.kt
+++ b/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/JvmSettingsRepositoryTest.kt
@@ -1,0 +1,41 @@
+package com.example.pekomon.minesweeper.settings
+
+import com.example.pekomon.minesweeper.game.Difficulty
+import java.util.UUID
+import java.util.prefs.BackingStoreException
+import java.util.prefs.Preferences
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class JvmSettingsRepositoryTest {
+    private lateinit var preferences: Preferences
+    private lateinit var repository: JvmSettingsRepository
+
+    @BeforeTest
+    fun setUp() {
+        val nodeName = "minesweeper-test-${UUID.randomUUID()}"
+        preferences = Preferences.userRoot().node(nodeName)
+        repository = JvmSettingsRepository(preferences)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        try {
+            preferences.removeNode()
+        } catch (_: BackingStoreException) {
+            // ignore cleanup failure
+        }
+    }
+
+    @Test
+    fun `round trips difficulty`() {
+        assertNull(repository.getSelectedDifficulty())
+
+        repository.setSelectedDifficulty(Difficulty.MEDIUM)
+
+        assertEquals(Difficulty.MEDIUM, repository.getSelectedDifficulty())
+    }
+}

--- a/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/SettingsMappingTest.kt
+++ b/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/SettingsMappingTest.kt
@@ -1,0 +1,23 @@
+package com.example.pekomon.minesweeper.settings
+
+import com.example.pekomon.minesweeper.game.Difficulty
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SettingsMappingTest {
+    @Test
+    fun `difficulty enum names map back to enum`() {
+        Difficulty.entries.forEach { difficulty ->
+            val stored = difficulty.name
+            val restored = runCatching { Difficulty.valueOf(stored) }.getOrNull()
+            assertEquals(difficulty, restored)
+        }
+    }
+
+    @Test
+    fun `invalid difficulty string returns null`() {
+        val restored = runCatching { Difficulty.valueOf("invalid") }.getOrNull()
+        assertNull(restored)
+    }
+}

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/main.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/main.kt
@@ -3,7 +3,7 @@ package com.example.pekomon.minesweeper
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
-import com.example.pekomon.minesweeper.ui.GameScreen
+import com.example.pekomon.minesweeper.MinesweeperContent
 import com.example.pekomon.minesweeper.ui.theme.MinesweeperTheme
 import kotlinx.browser.document
 
@@ -15,7 +15,7 @@ fun main() {
             loading?.parentNode?.removeChild(loading)
         }
         MinesweeperTheme(useDarkTheme = false) {
-            GameScreen()
+            MinesweeperContent()
         }
     }
 }

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
@@ -1,0 +1,21 @@
+package com.example.pekomon.minesweeper.settings
+
+import com.example.pekomon.minesweeper.game.Difficulty
+import kotlinx.browser.window
+
+private class WasmSettingsRepository : SettingsRepository {
+    private val storage = window.localStorage
+
+    override fun getSelectedDifficulty(): Difficulty? {
+        val stored = storage.getItem(SettingsKeys.SELECTED_DIFFICULTY) ?: return null
+        return runCatching { Difficulty.valueOf(stored) }.getOrNull()
+    }
+
+    override fun setSelectedDifficulty(value: Difficulty) {
+        storage.setItem(SettingsKeys.SELECTED_DIFFICULTY, value.name)
+    }
+}
+
+private val repository: SettingsRepository by lazy { WasmSettingsRepository() }
+
+actual fun provideSettingsRepository(): SettingsRepository = repository

--- a/Minesweeper/config/detekt/detekt.yml
+++ b/Minesweeper/config/detekt/detekt.yml
@@ -39,6 +39,9 @@ naming:
   MatchingDeclarationName:
     active: true
     excludes:
+      - '**/SettingsProvider.*.kt'
       - '**/Platform.*.kt'
+      - '**/*ViewController.*.kt'
+      - '**/*Activity.*.kt'
 
 

--- a/Minesweeper/gradle/libs.versions.toml
+++ b/Minesweeper/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ androidx-activity = "1.10.1"
 androidx-appcompat = "1.7.1"
 androidx-core = "1.17.0"
 androidx-core-splashscreen = "1.0.1"
+androidx-datastore = "1.1.1"
 androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.3"
 androidx-testExt = "1.3.0"
@@ -40,6 +41,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 compose-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Introduce a multiplatform SettingsRepository implementation backed by DataStore, NSUserDefaults, Java Preferences, and browser localStorage.
- Remember the chosen difficulty across app launches by integrating the repository with the shared UI and each platform entrypoint.
- Add JVM tests covering the repository mapping and document the cross-platform persistence in the README.

Closes #45
fixes #45

------
https://chatgpt.com/codex/tasks/task_b_68d81ee73ce0832f9821a7f2e636ab12