### PR TITLE
CI: report-only Spotless & Detekt; keep tests blocking

### DIFF
--- a/.github/workflows/minesweeper-ci.yml
+++ b/.github/workflows/minesweeper-ci.yml
@@ -13,8 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write           # tarvitaan format-jobin auto-commit/push
-  pull-requests: write
+  contents: read
 
 jobs:
   changes:
@@ -43,57 +42,9 @@ jobs:
               - 'gradle/libs.versions.toml'
               - '.github/workflows/**'
 
-  format:
-    name: Spotless Apply & Push
-    needs: [changes]
-    # PR: aina; push: vain jos Minesweeper-osui
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: Minesweeper
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref }}
-
-      - name: Setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
-
-      - name: Gradle build cache
-        uses: gradle/actions/setup-gradle@v4
-
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
-
-      - name: Spotless Apply
-        run: ./gradlew :composeApp:spotlessApply
-
-      - name: Commit and push formatting changes (PR only)
-        if: github.event_name == 'pull_request'
-        run: |
-          cd ..
-          if [[ -n "$(git status --porcelain)" ]]; then
-            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-              echo 'Skipping auto-commit for forked PR.'
-            else
-              git config user.name "github-actions[bot]"
-              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-              git add -A
-              git commit -m "chore: apply spotless formatting"
-              git push origin HEAD:${{ github.head_ref }}
-            fi
-          else
-            echo "No formatting changes."
-          fi
-
   quality:
     name: Quality (Spotless Check & Detekt)
-    needs: [changes, format]
+    needs: [changes]
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -117,8 +68,29 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Spotless Check & Detekt
-        run: ./gradlew :composeApp:spotlessCheck :composeApp:detekt
+      - name: Spotless Check
+        id: spotless_check
+        continue-on-error: true
+        run: ./gradlew :composeApp:spotlessCheck
+
+      - name: Detekt
+        id: detekt
+        continue-on-error: true
+        run: ./gradlew :composeApp:detekt
+
+      - name: Spotless Apply for patch
+        if: always() && steps.spotless_check.outcome == 'failure'
+        run: ./gradlew :composeApp:spotlessApply
+
+      - name: Generate Spotless patch
+        if: always() && steps.spotless_check.outcome == 'failure'
+        run: |
+          cd ..
+          if git diff --quiet; then
+            echo "No changes from spotlessApply."
+          else
+            git diff --binary > spotless.patch
+          fi
 
       - name: Upload Detekt reports
         if: always()
@@ -130,9 +102,17 @@ jobs:
             Minesweeper/composeApp/build/reports/detekt/*.xml
           if-no-files-found: warn
 
+      - name: Upload Spotless patch
+        if: always() && steps.spotless_check.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotless-patch
+          path: ../spotless.patch
+          if-no-files-found: ignore
+
   tests:
     name: JVM Tests & Coverage
-    needs: [changes, format, quality]
+    needs: [changes]
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -171,7 +151,7 @@ jobs:
 
   android:
     name: Android (assembleDebug)
-    needs: [changes, format, quality, tests]
+    needs: [tests]
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -210,7 +190,7 @@ jobs:
 
   desktop:
     name: Desktop (uber-jar)
-    needs: [changes, format, quality, tests]
+    needs: [tests]
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -246,7 +226,7 @@ jobs:
 
   wasm:
     name: Wasm (production distribution)
-    needs: [changes, format, quality, tests]
+    needs: [tests]
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Summary
- drop the auto-format/push job and keep repository permissions at read-only
- run Spotless and Detekt in a report-only job that uploads Detekt reports and a Spotless patch when formatting fails
- keep JVM tests as the blocking gate for Android/Desktop/Wasm builds so platform builds still require tests to pass

fixes #56

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68d92ba2a468832f9c0d1c2d811ac83c