### PR TITLE
CI: run Minesweeper jobs only on Minesweeper changes (paths-filtered)

### DIFF
--- a/.github/workflows/minesweeper-ci.yml
+++ b/.github/workflows/minesweeper-ci.yml
@@ -45,7 +45,7 @@ jobs:
   quality:
     name: Quality (Spotless Check & Detekt)
     needs: [changes]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -113,7 +113,7 @@ jobs:
   tests:
     name: JVM Tests & Coverage
     needs: [changes]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -152,7 +152,7 @@ jobs:
   android:
     name: Android (assembleDebug)
     needs: [tests]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -191,7 +191,7 @@ jobs:
   desktop:
     name: Desktop (uber-jar)
     needs: [tests]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -227,7 +227,7 @@ jobs:
   wasm:
     name: Wasm (production distribution)
     needs: [tests]
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- remove the raw pull_request condition from Minesweeper jobs so they only run when workflow_dispatch fires or the paths filter reports Minesweeper changes

## Notes
- workflow still runs when manually dispatched and whenever Minesweeper-related paths change

## Testing
- CI (workflow file change ensures jobs run on this PR)


------
https://chatgpt.com/codex/tasks/task_b_68dfffbbd4f8832faccac2ba8ef0bdfd