### PR TITLE
Implement high-score celebration overlay with reduced-motion support

### DIFF
--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
@@ -32,7 +32,9 @@ private class AndroidSettingsRepository(
     }
 
     override fun isReducedMotionEnabled(): Boolean =
-        runBlocking { context.dataStore.data.first()[reducedMotionKey] ?: false }
+        runBlocking {
+            context.dataStore.data.first()[reducedMotionKey] ?: false
+        }
 
     override fun setReducedMotionEnabled(enabled: Boolean) {
         runBlocking {

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
@@ -1,6 +1,7 @@
 package com.example.pekomon.minesweeper.settings
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -14,6 +15,7 @@ private class AndroidSettingsRepository(
     private val context: Context,
 ) : SettingsRepository {
     private val difficultyKey = stringPreferencesKey(SettingsKeys.SELECTED_DIFFICULTY)
+    private val reducedMotionKey = booleanPreferencesKey(SettingsKeys.REDUCED_MOTION_ENABLED)
 
     override fun getSelectedDifficulty(): Difficulty? =
         runBlocking {
@@ -25,6 +27,17 @@ private class AndroidSettingsRepository(
         runBlocking {
             context.dataStore.edit { preferences ->
                 preferences[difficultyKey] = value.name
+            }
+        }
+    }
+
+    override fun isReducedMotionEnabled(): Boolean =
+        runBlocking { context.dataStore.data.first()[reducedMotionKey] ?: false }
+
+    override fun setReducedMotionEnabled(enabled: Boolean) {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                preferences[reducedMotionKey] = enabled
             }
         }
     }

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
@@ -54,7 +54,11 @@ private object AndroidSettingsHolder {
     }
 
     fun repository(): SettingsRepository =
-        repository ?: error("SettingsRepository not initialized. Call initializeSettingsRepository(context) first.")
+        repository
+            ?: error(
+                "SettingsRepository not initialized. " +
+                    "Call initializeSettingsRepository(context) first.",
+            )
 }
 
 fun initializeSettingsRepository(context: Context) {

--- a/Minesweeper/composeApp/src/commonMain/composeResources/values-fi/strings.xml
+++ b/Minesweeper/composeApp/src/commonMain/composeResources/values-fi/strings.xml
@@ -11,4 +11,7 @@
     <string name="history_no_wins">Ei voittoja tasolla %1$s vielä.</string>
     <string name="history_button">Historia</string>
     <string name="reset_button">Aloita alusta</string>
+    <string name="new_record_title">Uusi ennätys!</string>
+    <string name="new_record_time">Aika: %1$s</string>
+    <string name="new_record_difficulty">Vaikeustaso: %1$s</string>
 </resources>

--- a/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -11,4 +11,7 @@
     <string name="history_no_wins">No wins recorded for %1$s yet.</string>
     <string name="history_button">History</string>
     <string name="reset_button">Reset</string>
+    <string name="new_record_title">New record!</string>
+    <string name="new_record_time">Time: %1$s</string>
+    <string name="new_record_difficulty">Difficulty: %1$s</string>
 </resources>

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
@@ -34,11 +34,13 @@ fun MinesweeperContent() {
             runCatching { provideHistoryStore() }.getOrElse { InMemoryHistoryStore() }
         }
     var storedDifficulty by remember { mutableStateOf(settingsRepository.getSelectedDifficulty()) }
+    val reducedMotionEnabled = remember { settingsRepository.isReducedMotionEnabled() }
     val initialDifficulty = storedDifficulty ?: Difficulty.EASY
 
     GameScreen(
         initialDifficulty = initialDifficulty,
         historyStore = historyStore,
+        reducedMotionEnabled = reducedMotionEnabled,
         onDifficultyChanged = {
             storedDifficulty = it
             settingsRepository.setSelectedDifficulty(it)
@@ -48,10 +50,17 @@ fun MinesweeperContent() {
 
 private class InMemorySettingsRepository : SettingsRepository {
     private var difficulty: Difficulty? = null
+    private var reducedMotionEnabled: Boolean = false
 
     override fun getSelectedDifficulty(): Difficulty? = difficulty
 
     override fun setSelectedDifficulty(value: Difficulty) {
         difficulty = value
+    }
+
+    override fun isReducedMotionEnabled(): Boolean = reducedMotionEnabled
+
+    override fun setReducedMotionEnabled(enabled: Boolean) {
+        reducedMotionEnabled = enabled
     }
 }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/history/RunRecord.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/history/RunRecord.kt
@@ -9,3 +9,21 @@ data class RunRecord(
     val millis: Long,
     val epochMillis: Long,
 )
+
+fun isNewRecord(
+    currentMillis: Long,
+    difficulty: Difficulty,
+    history: List<RunRecord>,
+): Boolean {
+    if (currentMillis < 0) {
+        return false
+    }
+
+    val bestRecord =
+        history
+            .asSequence()
+            .filter { it.difficulty == difficulty }
+            .minWithOrNull(compareBy<RunRecord> { it.millis }.thenBy { it.epochMillis })
+
+    return bestRecord == null || currentMillis < bestRecord.millis
+}

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
@@ -10,10 +10,15 @@ interface SettingsRepository {
     fun getSelectedDifficulty(): Difficulty? // null = not set
 
     fun setSelectedDifficulty(value: Difficulty)
+
+    fun isReducedMotionEnabled(): Boolean
+
+    fun setReducedMotionEnabled(enabled: Boolean)
 }
 
 object SettingsKeys {
     const val SELECTED_DIFFICULTY = "selected_difficulty"
+    const val REDUCED_MOTION_ENABLED = "reduced_motion_enabled"
 }
 
 /** Expect a platform-specific provider so common UI can obtain the repo. */

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ConfettiOverlay.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ConfettiOverlay.kt
@@ -1,0 +1,166 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+@Composable
+fun ConfettiOverlay(
+    modifier: Modifier = Modifier,
+    particleCount: Int = 120,
+    animationDurationMillis: Int = 4_000,
+    colors: List<Color> = emptyList(),
+) {
+    if (particleCount <= 0 || animationDurationMillis <= 0) {
+        return
+    }
+
+    val palette = if (colors.isEmpty()) defaultConfettiColors() else colors
+    val particles = remember(palette, particleCount, animationDurationMillis) {
+        createParticles(palette, particleCount, animationDurationMillis)
+    }
+    val transition = rememberInfiniteTransition(label = "confetti-transition")
+    val animations = remember(particles, animationDurationMillis) {
+        particles.mapIndexed { index, particle ->
+            val duration = particle.durationMillis(animationDurationMillis)
+            transition.animateFloat(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec =
+                    infiniteRepeatable(
+                        animation = tween(durationMillis = duration, easing = LinearEasing),
+                        initialStartOffset = StartOffset(particle.startDelayMillis),
+                    ),
+                label = "confetti-progress-$index",
+            )
+        }
+    }
+
+    val density = LocalDensity.current
+    Canvas(modifier = modifier) {
+        drawConfettiParticles(
+            particles = particles,
+            animations = animations,
+            density = density,
+        )
+    }
+}
+
+@Composable
+private fun defaultConfettiColors(): List<Color> =
+    listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.secondary,
+        MaterialTheme.colorScheme.tertiary,
+        MaterialTheme.colorScheme.primaryContainer,
+        MaterialTheme.colorScheme.secondaryContainer,
+    )
+
+@Immutable
+private data class ConfettiParticle(
+    val color: Color,
+    val startFractionX: Float,
+    val swayAmplitude: Float,
+    val swayFrequency: Float,
+    val swayPhase: Float,
+    val size: Dp,
+    val rotationSpeed: Float,
+    val speedMultiplier: Float,
+    val startDelayMillis: Int,
+)
+
+private fun createParticles(
+    palette: List<Color>,
+    count: Int,
+    baseDurationMillis: Int,
+): List<ConfettiParticle> {
+    val random = Random
+    return List(count) {
+        ConfettiParticle(
+            color = palette[random.nextInt(palette.size)],
+            startFractionX = random.nextFloat(),
+            swayAmplitude = random.nextFloatInRange(0.05f, 0.3f),
+            swayFrequency = random.nextFloatInRange(0.8f, 1.8f),
+            swayPhase = random.nextFloatInRange(0f, (2f * PI).toFloat()),
+            size = random.nextFloatInRange(8f, 14f).dp,
+            rotationSpeed = random.nextFloatInRange(0.6f, 2.2f),
+            speedMultiplier = random.nextFloatInRange(0.8f, 1.4f),
+            startDelayMillis = random.nextInt(baseDurationMillis),
+        )
+    }
+}
+
+private fun ConfettiParticle.durationMillis(baseDuration: Int): Int {
+    val scaled = (baseDuration * speedMultiplier).roundToInt()
+    return scaled.coerceAtLeast(1)
+}
+
+private fun DrawScope.drawConfettiParticles(
+    particles: List<ConfettiParticle>,
+    animations: List<State<Float>>,
+    density: Density,
+) {
+    val width = size.width
+    val height = size.height
+    particles.forEachIndexed { index, particle ->
+        val progress = animations[index].value
+        val sizePx = with(density) { particle.size.toPx() }
+        val confettiHeight = sizePx * 0.45f
+        val y = height * progress - confettiHeight
+        val x = width * particle.xFraction(progress)
+        val rotation = particle.rotationDegrees(progress)
+        rotate(degrees = rotation, pivot = Offset(x, y + confettiHeight / 2f)) {
+            drawRoundRect(
+                color = particle.color,
+                topLeft = Offset(x - sizePx / 2f, y),
+                size = Size(width = sizePx, height = confettiHeight),
+                cornerRadius = CornerRadius(confettiHeight / 2f, confettiHeight / 2f),
+            )
+        }
+    }
+}
+
+private fun ConfettiParticle.xFraction(progress: Float): Float {
+    val oscillation = sin((progress * swayFrequency + swayPhase) * PI * 2f)
+    return wrap01(startFractionX + swayAmplitude * oscillation)
+}
+
+private fun ConfettiParticle.rotationDegrees(progress: Float): Float =
+    (progress * 360f * rotationSpeed) % 360f
+
+private fun wrap01(value: Float): Float {
+    var result = value % 1f
+    if (result < 0f) {
+        result += 1f
+    }
+    return result
+}
+
+private fun Random.nextFloatInRange(min: Float, max: Float): Float {
+    require(min <= max) { "min must be <= max" }
+    return min + nextFloat() * (max - min)
+}

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ConfettiOverlay.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ConfettiOverlay.kt
@@ -44,20 +44,21 @@ fun ConfettiOverlay(
         createParticles(palette, particleCount, animationDurationMillis)
     }
     val transition = rememberInfiniteTransition(label = "confetti-transition")
-    val animations = remember(particles, animationDurationMillis) {
-        particles.mapIndexed { index, particle ->
-            val duration = particle.durationMillis(animationDurationMillis)
-            transition.animateFloat(
-                initialValue = 0f,
-                targetValue = 1f,
-                animationSpec =
-                    infiniteRepeatable(
-                        animation = tween(durationMillis = duration, easing = LinearEasing),
-                        initialStartOffset = StartOffset(particle.startDelayMillis),
-                    ),
-                label = "confetti-progress-$index",
-            )
-        }
+    val animationDurations = remember(particles, animationDurationMillis) {
+        particles.map { it.durationMillis(animationDurationMillis) }
+    }
+    val animations = particles.mapIndexed { index, particle ->
+        val duration = animationDurations[index]
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation = tween(durationMillis = duration, easing = LinearEasing),
+                    initialStartOffset = StartOffset(particle.startDelayMillis),
+                ),
+            label = "confetti-progress-$index",
+        )
     }
 
     val density = LocalDensity.current
@@ -145,7 +146,7 @@ private fun DrawScope.drawConfettiParticles(
 }
 
 private fun ConfettiParticle.xFraction(progress: Float): Float {
-    val oscillation = sin((progress * swayFrequency + swayPhase) * PI * 2f)
+    val oscillation = sin((progress * swayFrequency + swayPhase) * PI * 2f).toFloat()
     return wrap01(startFractionX + swayAmplitude * oscillation)
 }
 

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ConfettiOverlay.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ConfettiOverlay.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.math.PI
-import kotlin.math.sin
 import kotlin.math.roundToInt
+import kotlin.math.sin
 import kotlin.random.Random
 
 @Composable
@@ -40,26 +40,29 @@ fun ConfettiOverlay(
     }
 
     val palette = if (colors.isEmpty()) defaultConfettiColors() else colors
-    val particles = remember(palette, particleCount, animationDurationMillis) {
-        createParticles(palette, particleCount, animationDurationMillis)
-    }
+    val particles =
+        remember(palette, particleCount, animationDurationMillis) {
+            createParticles(palette, particleCount, animationDurationMillis)
+        }
     val transition = rememberInfiniteTransition(label = "confetti-transition")
-    val animationDurations = remember(particles, animationDurationMillis) {
-        particles.map { it.durationMillis(animationDurationMillis) }
-    }
-    val animations = particles.mapIndexed { index, particle ->
-        val duration = animationDurations[index]
-        transition.animateFloat(
-            initialValue = 0f,
-            targetValue = 1f,
-            animationSpec =
-                infiniteRepeatable(
-                    animation = tween(durationMillis = duration, easing = LinearEasing),
-                    initialStartOffset = StartOffset(particle.startDelayMillis),
-                ),
-            label = "confetti-progress-$index",
-        )
-    }
+    val animationDurations =
+        remember(particles, animationDurationMillis) {
+            particles.map { it.durationMillis(animationDurationMillis) }
+        }
+    val animations =
+        particles.mapIndexed { index, particle ->
+            val duration = animationDurations[index]
+            transition.animateFloat(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec =
+                    infiniteRepeatable(
+                        animation = tween(durationMillis = duration, easing = LinearEasing),
+                        initialStartOffset = StartOffset(particle.startDelayMillis),
+                    ),
+                label = "confetti-progress-$index",
+            )
+        }
 
     val density = LocalDensity.current
     Canvas(modifier = modifier) {
@@ -150,8 +153,7 @@ private fun ConfettiParticle.xFraction(progress: Float): Float {
     return wrap01(startFractionX + swayAmplitude * oscillation)
 }
 
-private fun ConfettiParticle.rotationDegrees(progress: Float): Float =
-    (progress * 360f * rotationSpeed) % 360f
+private fun ConfettiParticle.rotationDegrees(progress: Float): Float = (progress * 360f * rotationSpeed) % 360f
 
 private fun wrap01(value: Float): Float {
     var result = value % 1f
@@ -161,7 +163,10 @@ private fun wrap01(value: Float): Float {
     return result
 }
 
-private fun Random.nextFloatInRange(min: Float, max: Float): Float {
+private fun Random.nextFloatInRange(
+    min: Float,
+    max: Float,
+): Float {
     require(min <= max) { "min must be <= max" }
     return min + nextFloat() * (max - min)
 }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
@@ -231,7 +230,7 @@ fun GameScreen(
                     ConfettiOverlay(
                         modifier =
                             Modifier
-                                .matchParentSize()
+                                .fillMaxSize()
                                 .align(Alignment.Center)
                                 .zIndex(0.5f),
                     )

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Dp.Companion.Infinity
 import androidx.compose.ui.unit.Dp.Companion.Unspecified
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.example.pekomon.minesweeper.composeapp.generated.resources.Res
 import com.example.pekomon.minesweeper.composeapp.generated.resources.difficulty
 import com.example.pekomon.minesweeper.composeapp.generated.resources.difficulty_easy
@@ -78,11 +79,10 @@ import com.example.pekomon.minesweeper.i18n.t
 import com.example.pekomon.minesweeper.lifecycle.AppLifecycle
 import com.example.pekomon.minesweeper.lifecycle.AppLifecycleObserver
 import com.example.pekomon.minesweeper.timer.GameTimerState
-import com.example.pekomon.minesweeper.util.formatMillisToMmSs
 import com.example.pekomon.minesweeper.ui.theme.flaggedCellColor
 import com.example.pekomon.minesweeper.ui.theme.hiddenCellColor
 import com.example.pekomon.minesweeper.ui.theme.revealedCellColor
-import androidx.compose.ui.zIndex
+import com.example.pekomon.minesweeper.util.formatMillisToMmSs
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import org.jetbrains.compose.resources.StringResource

--- a/Minesweeper/composeApp/src/commonTest/kotlin/com/example/pekomon/minesweeper/history/RunHistoryTest.kt
+++ b/Minesweeper/composeApp/src/commonTest/kotlin/com/example/pekomon/minesweeper/history/RunHistoryTest.kt
@@ -1,0 +1,76 @@
+package com.example.pekomon.minesweeper.history
+
+import com.example.pekomon.minesweeper.game.Difficulty
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RunHistoryTest {
+    @Test
+    fun `returns true when history empty`() {
+        val isRecord = isNewRecord(currentMillis = 1_000L, difficulty = Difficulty.EASY, history = emptyList())
+
+        assertTrue(isRecord)
+    }
+
+    @Test
+    fun `returns true when faster than best`() {
+        val history =
+            listOf(
+                RunRecord(difficulty = Difficulty.EASY, millis = 5_000L, epochMillis = 1L),
+                RunRecord(difficulty = Difficulty.EASY, millis = 6_000L, epochMillis = 2L),
+            )
+
+        val isRecord = isNewRecord(currentMillis = 4_000L, difficulty = Difficulty.EASY, history = history)
+
+        assertTrue(isRecord)
+    }
+
+    @Test
+    fun `returns false when slower than best`() {
+        val history =
+            listOf(
+                RunRecord(difficulty = Difficulty.EASY, millis = 3_000L, epochMillis = 1L),
+                RunRecord(difficulty = Difficulty.EASY, millis = 4_000L, epochMillis = 2L),
+            )
+
+        val isRecord = isNewRecord(currentMillis = 5_000L, difficulty = Difficulty.EASY, history = history)
+
+        assertFalse(isRecord)
+    }
+
+    @Test
+    fun `returns false when time matches best`() {
+        val history =
+            listOf(
+                RunRecord(difficulty = Difficulty.EASY, millis = 3_000L, epochMillis = 1L),
+                RunRecord(difficulty = Difficulty.EASY, millis = 4_000L, epochMillis = 2L),
+            )
+
+        val isRecord = isNewRecord(currentMillis = 3_000L, difficulty = Difficulty.EASY, history = history)
+
+        assertFalse(isRecord)
+    }
+
+    @Test
+    fun `ignores runs from other difficulties`() {
+        val history =
+            listOf(
+                RunRecord(difficulty = Difficulty.MEDIUM, millis = 2_000L, epochMillis = 1L),
+                RunRecord(difficulty = Difficulty.HARD, millis = 1_500L, epochMillis = 2L),
+            )
+
+        val isRecord = isNewRecord(currentMillis = 4_000L, difficulty = Difficulty.EASY, history = history)
+
+        assertTrue(isRecord)
+    }
+
+    @Test
+    fun `returns false for negative durations`() {
+        val history = listOf(RunRecord(difficulty = Difficulty.EASY, millis = 2_000L, epochMillis = 1L))
+
+        val isRecord = isNewRecord(currentMillis = -100L, difficulty = Difficulty.EASY, history = history)
+
+        assertFalse(isRecord)
+    }
+}

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
@@ -14,6 +14,13 @@ private class IosSettingsRepository : SettingsRepository {
     override fun setSelectedDifficulty(value: Difficulty) {
         defaults.setObject(value.name, forKey = SettingsKeys.SELECTED_DIFFICULTY)
     }
+
+    override fun isReducedMotionEnabled(): Boolean =
+        defaults.boolForKey(SettingsKeys.REDUCED_MOTION_ENABLED)
+
+    override fun setReducedMotionEnabled(enabled: Boolean) {
+        defaults.setBool(enabled, forKey = SettingsKeys.REDUCED_MOTION_ENABLED)
+    }
 }
 
 private val repository: SettingsRepository by lazy { IosSettingsRepository() }

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
@@ -15,8 +15,7 @@ private class IosSettingsRepository : SettingsRepository {
         defaults.setObject(value.name, forKey = SettingsKeys.SELECTED_DIFFICULTY)
     }
 
-    override fun isReducedMotionEnabled(): Boolean =
-        defaults.boolForKey(SettingsKeys.REDUCED_MOTION_ENABLED)
+    override fun isReducedMotionEnabled(): Boolean = defaults.boolForKey(SettingsKeys.REDUCED_MOTION_ENABLED)
 
     override fun setReducedMotionEnabled(enabled: Boolean) {
         defaults.setBool(enabled, forKey = SettingsKeys.REDUCED_MOTION_ENABLED)

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
@@ -14,6 +14,13 @@ internal class JvmSettingsRepository(
     override fun setSelectedDifficulty(value: Difficulty) {
         preferences.put(SettingsKeys.SELECTED_DIFFICULTY, value.name)
     }
+
+    override fun isReducedMotionEnabled(): Boolean =
+        preferences.getBoolean(SettingsKeys.REDUCED_MOTION_ENABLED, false)
+
+    override fun setReducedMotionEnabled(enabled: Boolean) {
+        preferences.putBoolean(SettingsKeys.REDUCED_MOTION_ENABLED, enabled)
+    }
 }
 
 private val repository: SettingsRepository by lazy {

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
@@ -15,8 +15,7 @@ internal class JvmSettingsRepository(
         preferences.put(SettingsKeys.SELECTED_DIFFICULTY, value.name)
     }
 
-    override fun isReducedMotionEnabled(): Boolean =
-        preferences.getBoolean(SettingsKeys.REDUCED_MOTION_ENABLED, false)
+    override fun isReducedMotionEnabled(): Boolean = preferences.getBoolean(SettingsKeys.REDUCED_MOTION_ENABLED, false)
 
     override fun setReducedMotionEnabled(enabled: Boolean) {
         preferences.putBoolean(SettingsKeys.REDUCED_MOTION_ENABLED, enabled)

--- a/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/JvmSettingsRepositoryTest.kt
+++ b/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/JvmSettingsRepositoryTest.kt
@@ -38,4 +38,13 @@ class JvmSettingsRepositoryTest {
 
         assertEquals(Difficulty.MEDIUM, repository.getSelectedDifficulty())
     }
+
+    @Test
+    fun `round trips reduced motion`() {
+        assertEquals(false, repository.isReducedMotionEnabled())
+
+        repository.setReducedMotionEnabled(true)
+
+        assertEquals(true, repository.isReducedMotionEnabled())
+    }
 }

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
@@ -16,7 +16,10 @@ private class WasmSettingsRepository : SettingsRepository {
     }
 
     override fun isReducedMotionEnabled(): Boolean =
-        storage.getItem(SettingsKeys.REDUCED_MOTION_ENABLED)?.toBoolean() ?: false
+        storage
+            .getItem(SettingsKeys.REDUCED_MOTION_ENABLED)
+            ?.toBoolean()
+            ?: false
 
     override fun setReducedMotionEnabled(enabled: Boolean) {
         storage.setItem(SettingsKeys.REDUCED_MOTION_ENABLED, enabled.toString())

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
@@ -14,6 +14,13 @@ private class WasmSettingsRepository : SettingsRepository {
     override fun setSelectedDifficulty(value: Difficulty) {
         storage.setItem(SettingsKeys.SELECTED_DIFFICULTY, value.name)
     }
+
+    override fun isReducedMotionEnabled(): Boolean =
+        storage.getItem(SettingsKeys.REDUCED_MOTION_ENABLED)?.toBoolean() ?: false
+
+    override fun setReducedMotionEnabled(enabled: Boolean) {
+        storage.setItem(SettingsKeys.REDUCED_MOTION_ENABLED, enabled.toString())
+    }
 }
 
 private val repository: SettingsRepository by lazy { WasmSettingsRepository() }


### PR DESCRIPTION
## Summary
- show a localized “New record!” banner and confetti celebration whenever a run beats the best time, respecting the reduced-motion setting
- add a reusable Compose confetti overlay animation and persist the reduced-motion preference across all settings repositories
- expose the high-score helper and cover it with common unit tests

fixes #47

## Testing
- `./gradlew :composeApp:check` *(fails: plugin org.jetbrains.kotlin.plugin.serialization:2.2.10 unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0139f0a20832fb0196dab1bd4d90d