### PR TITLE
chore(mw): adopt AndroidX Compose BOM + safe dependency bumps

### DIFF
--- a/Minesweeper/composeApp/build.gradle.kts
+++ b/Minesweeper/composeApp/build.gradle.kts
@@ -54,7 +54,12 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                implementation(project.dependencies.platform(libs.androidx.compose.bom.get()))
+                implementation(
+                    project.dependencies.platform(
+                        libs.androidx.compose.bom
+                            .get(),
+                    ),
+                )
                 implementation(libs.androidx.compose.foundation)
                 implementation(libs.androidx.compose.material3)
                 implementation(libs.androidx.compose.ui)
@@ -128,7 +133,12 @@ android {
 }
 
 dependencies {
-    debugImplementation(project.dependencies.platform(libs.androidx.compose.bom.get()))
+    debugImplementation(
+        project.dependencies.platform(
+            libs.androidx.compose.bom
+                .get(),
+        ),
+    )
     debugImplementation(compose.uiTooling)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/Minesweeper/composeApp/build.gradle.kts
+++ b/Minesweeper/composeApp/build.gradle.kts
@@ -54,6 +54,12 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
+                implementation(project.dependencies.platform(libs.androidx.compose.bom.get()))
+                implementation(libs.androidx.compose.foundation)
+                implementation(libs.androidx.compose.material3)
+                implementation(libs.androidx.compose.ui)
+                implementation(libs.androidx.compose.ui.graphics)
+                implementation(libs.androidx.compose.ui.tooling.preview)
                 implementation(compose.preview)
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.androidx.core.splashscreen)
@@ -122,7 +128,9 @@ android {
 }
 
 dependencies {
+    debugImplementation(project.dependencies.platform(libs.androidx.compose.bom.get()))
     debugImplementation(compose.uiTooling)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 }
 
 compose.desktop {

--- a/Minesweeper/gradle/libs.versions.toml
+++ b/Minesweeper/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-datastore = "1.1.1"
 androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.3"
 androidx-testExt = "1.3.0"
+compose-bom = "2024.10.01"
 composeHotReload = "1.0.0-beta06"
 composeMultiplatform = "1.8.2"
 detekt = "1.23.6"
@@ -38,6 +39,13 @@ androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecyc
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
## Summary
- Adopted the AndroidX Compose BOM for Android-specific dependencies in composeApp while keeping JetBrains Compose MPP usages intact.
- Added versionless AndroidX Compose coordinates managed by the BOM for androidMain and debug configurations.

## Testing
- ⚠️ `./gradlew spotlessCheck detekt` *(fails: could not download com.pinterest.ktlint:ktlint-cli:1.3.1 due to HTTP 403 from Maven Central).* 

- [x] Adopted AndroidX Compose BOM for Android artifacts in composeApp.
- [x] Left JetBrains Compose MPP artifacts untouched.
- [x] No app-code migrations; safe dependency bumps only.
- [ ] Spotless/Detekt pass locally (blocked by 403 fetching ktlint-cli; formatting kept consistent with existing style).
- [x] Minesweeper-only changes; CryptoApp untouched.

fixes #44

------
https://chatgpt.com/codex/tasks/task_b_68e1114dbf48832f97ef84014b42200c