### PR TITLE
feat(mw): animations & synthetic sounds (+settings toggles)

### DIFF
--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/MainActivity.kt
@@ -113,6 +113,10 @@ private fun LegacySplash() {
 fun GameScreenAndroidPreview() {
     AndroidMinesweeperTheme {
         val historyStore = remember { InMemoryHistoryStore() }
-        GameScreen(historyStore = historyStore)
+        GameScreen(
+            historyStore = historyStore,
+            soundsEnabled = true,
+            animationsEnabled = true,
+        )
     }
 }

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.android.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.android.kt
@@ -34,7 +34,11 @@ private object AndroidSoundPlayer : SoundPlayer {
         playTone(tone = ToneGenerator.TONE_DTMF_2, durationMs = 320)
     }
 
-    private fun playTone(tone: Int, durationMs: Int, delayBeforeMs: Long = 0L) {
+    private fun playTone(
+        tone: Int,
+        durationMs: Int,
+        delayBeforeMs: Long = 0L,
+    ) {
         scope.launch {
             if (delayBeforeMs > 0) {
                 delay(delayBeforeMs)

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.android.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.android.kt
@@ -1,0 +1,65 @@
+package com.example.pekomon.minesweeper.audio
+
+import android.media.AudioManager
+import android.media.ToneGenerator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private object AndroidSoundPlayer : SoundPlayer {
+    private val toneGenerator = ToneGenerator(AudioManager.STREAM_MUSIC, 80)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    override fun click() {
+        playTone(tone = ToneGenerator.TONE_DTMF_1, durationMs = 80)
+    }
+
+    override fun reveal() {
+        playTone(tone = ToneGenerator.TONE_DTMF_5, durationMs = 90)
+    }
+
+    override fun win() {
+        playSequence(
+            ToneSegment(tone = ToneGenerator.TONE_DTMF_6, durationMs = 110, delayBeforeMs = 0),
+            ToneSegment(tone = ToneGenerator.TONE_DTMF_8, durationMs = 120, delayBeforeMs = 120),
+            ToneSegment(tone = ToneGenerator.TONE_DTMF_A, durationMs = 150, delayBeforeMs = 140),
+        )
+    }
+
+    override fun lose() {
+        playTone(tone = ToneGenerator.TONE_DTMF_2, durationMs = 320)
+    }
+
+    private fun playTone(tone: Int, durationMs: Int, delayBeforeMs: Long = 0L) {
+        scope.launch {
+            if (delayBeforeMs > 0) {
+                delay(delayBeforeMs)
+            }
+            toneGenerator.startTone(tone, durationMs)
+        }
+    }
+
+    private fun playSequence(vararg segments: ToneSegment) {
+        scope.launch {
+            segments.forEachIndexed { index, segment ->
+                if (segment.delayBeforeMs > 0 && index != 0) {
+                    delay(segment.delayBeforeMs)
+                }
+                toneGenerator.startTone(segment.tone, segment.durationMs)
+            }
+        }
+    }
+}
+
+private data class ToneSegment(
+    val tone: Int,
+    val durationMs: Int,
+    val delayBeforeMs: Long,
+)
+
+@Composable
+actual fun rememberPlatformSoundPlayer(): SoundPlayer = remember { AndroidSoundPlayer }

--- a/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
+++ b/Minesweeper/composeApp/src/androidMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.android.kt
@@ -15,7 +15,8 @@ private class AndroidSettingsRepository(
     private val context: Context,
 ) : SettingsRepository {
     private val difficultyKey = stringPreferencesKey(SettingsKeys.SELECTED_DIFFICULTY)
-    private val reducedMotionKey = booleanPreferencesKey(SettingsKeys.REDUCED_MOTION_ENABLED)
+    private val soundKey = booleanPreferencesKey(SettingsKeys.ENABLE_SOUNDS)
+    private val animationKey = booleanPreferencesKey(SettingsKeys.ENABLE_ANIMATIONS)
 
     override fun getSelectedDifficulty(): Difficulty? =
         runBlocking {
@@ -31,15 +32,28 @@ private class AndroidSettingsRepository(
         }
     }
 
-    override fun isReducedMotionEnabled(): Boolean =
+    override fun isSoundEnabled(): Boolean =
         runBlocking {
-            context.dataStore.data.first()[reducedMotionKey] ?: false
+            context.dataStore.data.first()[soundKey] ?: true
         }
 
-    override fun setReducedMotionEnabled(enabled: Boolean) {
+    override fun setSoundEnabled(enabled: Boolean) {
         runBlocking {
             context.dataStore.edit { preferences ->
-                preferences[reducedMotionKey] = enabled
+                preferences[soundKey] = enabled
+            }
+        }
+    }
+
+    override fun isAnimationEnabled(): Boolean =
+        runBlocking {
+            context.dataStore.data.first()[animationKey] ?: true
+        }
+
+    override fun setAnimationEnabled(enabled: Boolean) {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                preferences[animationKey] = enabled
             }
         }
     }

--- a/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="history_close">Close</string>
     <string name="history_no_wins">No wins recorded for %1$s yet.</string>
     <string name="history_button">History</string>
+    <string name="action_settings">Settings</string>
     <string name="reset_button">Reset</string>
     <string name="new_record_title">New record!</string>
     <string name="new_record_time">Time: %1$s</string>

--- a/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -12,7 +12,6 @@
     <string name="history_close">Close</string>
     <string name="history_no_wins">No wins recorded for %1$s yet.</string>
     <string name="history_button">History</string>
-    <string name="action_settings">Settings</string>
     <string name="reset_button">Reset</string>
     <string name="new_record_title">New record!</string>
     <string name="new_record_time">Time: %1$s</string>

--- a/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/Minesweeper/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,8 @@
     <string name="difficulty_hard">Hard</string>
     <string name="history_title">History</string>
     <string name="settings_title">Settings</string>
+    <string name="settings_sounds">Sounds</string>
+    <string name="settings_animations">Animations</string>
     <string name="timer_label">%1$s %2$ds</string>
     <string name="history_close">Close</string>
     <string name="history_no_wins">No wins recorded for %1$s yet.</string>

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/App.kt
@@ -34,23 +34,34 @@ fun MinesweeperContent() {
             runCatching { provideHistoryStore() }.getOrElse { InMemoryHistoryStore() }
         }
     var storedDifficulty by remember { mutableStateOf(settingsRepository.getSelectedDifficulty()) }
-    val reducedMotionEnabled = remember { settingsRepository.isReducedMotionEnabled() }
+    var soundsEnabled by remember { mutableStateOf(settingsRepository.isSoundEnabled()) }
+    var animationsEnabled by remember { mutableStateOf(settingsRepository.isAnimationEnabled()) }
     val initialDifficulty = storedDifficulty ?: Difficulty.EASY
 
     GameScreen(
         initialDifficulty = initialDifficulty,
         historyStore = historyStore,
-        reducedMotionEnabled = reducedMotionEnabled,
+        soundsEnabled = soundsEnabled,
+        animationsEnabled = animationsEnabled,
         onDifficultyChanged = {
             storedDifficulty = it
             settingsRepository.setSelectedDifficulty(it)
+        },
+        onSoundsEnabledChange = { enabled ->
+            soundsEnabled = enabled
+            settingsRepository.setSoundEnabled(enabled)
+        },
+        onAnimationsEnabledChange = { enabled ->
+            animationsEnabled = enabled
+            settingsRepository.setAnimationEnabled(enabled)
         },
     )
 }
 
 private class InMemorySettingsRepository : SettingsRepository {
     private var difficulty: Difficulty? = null
-    private var reducedMotionEnabled: Boolean = false
+    private var soundEnabled: Boolean = true
+    private var animationEnabled: Boolean = true
 
     override fun getSelectedDifficulty(): Difficulty? = difficulty
 
@@ -58,9 +69,15 @@ private class InMemorySettingsRepository : SettingsRepository {
         difficulty = value
     }
 
-    override fun isReducedMotionEnabled(): Boolean = reducedMotionEnabled
+    override fun isSoundEnabled(): Boolean = soundEnabled
 
-    override fun setReducedMotionEnabled(enabled: Boolean) {
-        reducedMotionEnabled = enabled
+    override fun setSoundEnabled(enabled: Boolean) {
+        soundEnabled = enabled
+    }
+
+    override fun isAnimationEnabled(): Boolean = animationEnabled
+
+    override fun setAnimationEnabled(enabled: Boolean) {
+        animationEnabled = enabled
     }
 }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.kt
@@ -1,0 +1,34 @@
+package com.example.pekomon.minesweeper.audio
+
+import androidx.compose.runtime.Composable
+
+interface SoundPlayer {
+    fun click()
+
+    fun reveal()
+
+    fun win()
+
+    fun lose()
+}
+
+object NullSoundPlayer : SoundPlayer {
+    override fun click() {}
+
+    override fun reveal() {}
+
+    override fun win() {}
+
+    override fun lose() {}
+}
+
+@Composable
+fun rememberSoundPlayer(enableSounds: Boolean): SoundPlayer =
+    if (enableSounds) {
+        rememberPlatformSoundPlayer()
+    } else {
+        NullSoundPlayer
+    }
+
+@Composable
+expect fun rememberPlatformSoundPlayer(): SoundPlayer

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.kt
@@ -13,13 +13,13 @@ interface SoundPlayer {
 }
 
 object NullSoundPlayer : SoundPlayer {
-    override fun click() {}
+    override fun click() { /* NOOP */ }
 
-    override fun reveal() {}
+    override fun reveal() { /* NOOP */ }
 
-    override fun win() {}
+    override fun win() { /* NOOP */ }
 
-    override fun lose() {}
+    override fun lose() { /* NOOP */ }
 }
 
 @Composable

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsRepository.kt
@@ -11,14 +11,19 @@ interface SettingsRepository {
 
     fun setSelectedDifficulty(value: Difficulty)
 
-    fun isReducedMotionEnabled(): Boolean
+    fun isSoundEnabled(): Boolean
 
-    fun setReducedMotionEnabled(enabled: Boolean)
+    fun setSoundEnabled(enabled: Boolean)
+
+    fun isAnimationEnabled(): Boolean
+
+    fun setAnimationEnabled(enabled: Boolean)
 }
 
 object SettingsKeys {
     const val SELECTED_DIFFICULTY = "selected_difficulty"
-    const val REDUCED_MOTION_ENABLED = "reduced_motion_enabled"
+    const val ENABLE_SOUNDS = "enable_sounds"
+    const val ENABLE_ANIMATIONS = "enable_animations"
 }
 
 /** Expect a platform-specific provider so common UI can obtain the repo. */

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContent.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContent.kt
@@ -1,10 +1,16 @@
 package com.example.pekomon.minesweeper.ui
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.graphicsLayer
 import com.example.pekomon.minesweeper.game.CellState
 import com.example.pekomon.minesweeper.ui.theme.numberColor
 
@@ -20,6 +26,34 @@ internal fun CellContent(
         return
     }
 
+    val reducedMotion = LocalReducedMotion.current
+    val shouldAnimate = !reducedMotion
+    val flagScaleRaw by animateFloatAsState(
+        targetValue =
+            when {
+                !shouldAnimate -> 1f
+                state == CellState.FLAGGED -> 1f
+                else -> 0.9f
+            },
+        animationSpec =
+            if (shouldAnimate) {
+                tween(durationMillis = 120, easing = FastOutSlowInEasing)
+            } else {
+                snap()
+            },
+        label = "flagPop",
+    )
+    val scaleModifier =
+        if (state == CellState.FLAGGED && shouldAnimate) {
+            modifier.graphicsLayer {
+                val scale = flagScaleRaw
+                scaleX = scale
+                scaleY = scale
+            }
+        } else {
+            modifier
+        }
+
     Text(
         text = content,
         color = cellContentColor(state, isMine, adjacentMines),
@@ -30,7 +64,7 @@ internal fun CellContent(
                 FontWeight.Normal
             },
         style = MaterialTheme.typography.bodyLarge,
-        modifier = modifier,
+        modifier = scaleModifier,
     )
 }
 

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContent.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/CellContent.kt
@@ -9,8 +9,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
 import com.example.pekomon.minesweeper.game.CellState
 import com.example.pekomon.minesweeper.ui.theme.numberColor
 

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -78,6 +78,7 @@ import com.example.pekomon.minesweeper.composeapp.generated.resources.new_record
 import com.example.pekomon.minesweeper.composeapp.generated.resources.new_record_time
 import com.example.pekomon.minesweeper.composeapp.generated.resources.new_record_title
 import com.example.pekomon.minesweeper.composeapp.generated.resources.reset_button
+import com.example.pekomon.minesweeper.composeapp.generated.resources.settings_title
 import com.example.pekomon.minesweeper.composeapp.generated.resources.timer_label
 import com.example.pekomon.minesweeper.game.Board
 import com.example.pekomon.minesweeper.game.Cell

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -421,7 +421,7 @@ private fun GameTopBar(
                         DropdownMenuItem(
                             text = {
                                 Text(
-                                    text = t(Res.string.action_settings),
+                                    text = t(Res.string.settings_title),
                                     style = MaterialTheme.typography.bodyLarge,
                                 )
                             },

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -2,12 +2,12 @@ package com.example.pekomon.minesweeper.ui
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -463,7 +463,11 @@ private fun DifficultyButton(
             modifier =
                 Modifier
                     .heightIn(min = 48.dp)
-                    .pressScale(interactionSource = interactionSource, animationsEnabled = animationsEnabled, label = "difficultyPress"),
+                    .pressScale(
+                        interactionSource = interactionSource,
+                        animationsEnabled = animationsEnabled,
+                        label = "difficultyPress"
+                    ),
             interactionSource = interactionSource,
             contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
         ) {

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -1,9 +1,16 @@
 package com.example.pekomon.minesweeper.ui
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -27,10 +34,12 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -39,6 +48,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -50,11 +60,14 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Dp.Companion.Infinity
 import androidx.compose.ui.unit.Dp.Companion.Unspecified
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.example.pekomon.minesweeper.audio.SoundPlayer
+import com.example.pekomon.minesweeper.audio.rememberSoundPlayer
 import com.example.pekomon.minesweeper.composeapp.generated.resources.Res
 import com.example.pekomon.minesweeper.composeapp.generated.resources.difficulty
 import com.example.pekomon.minesweeper.composeapp.generated.resources.difficulty_easy
@@ -94,8 +107,36 @@ fun GameScreen(
     modifier: Modifier = Modifier,
     initialDifficulty: Difficulty = Difficulty.EASY,
     historyStore: HistoryStore,
-    reducedMotionEnabled: Boolean = false,
+    soundsEnabled: Boolean,
+    animationsEnabled: Boolean,
     onDifficultyChanged: (Difficulty) -> Unit = {},
+    onSoundsEnabledChange: (Boolean) -> Unit = {},
+    onAnimationsEnabledChange: (Boolean) -> Unit = {},
+) {
+    CompositionLocalProvider(LocalReducedMotion provides !animationsEnabled) {
+        GameScreenContent(
+            modifier = modifier,
+            initialDifficulty = initialDifficulty,
+            historyStore = historyStore,
+            soundsEnabled = soundsEnabled,
+            animationsEnabled = animationsEnabled,
+            onDifficultyChanged = onDifficultyChanged,
+            onSoundsEnabledChange = onSoundsEnabledChange,
+            onAnimationsEnabledChange = onAnimationsEnabledChange,
+        )
+    }
+}
+
+@Composable
+private fun GameScreenContent(
+    modifier: Modifier = Modifier,
+    initialDifficulty: Difficulty = Difficulty.EASY,
+    historyStore: HistoryStore,
+    soundsEnabled: Boolean,
+    animationsEnabled: Boolean,
+    onDifficultyChanged: (Difficulty) -> Unit,
+    onSoundsEnabledChange: (Boolean) -> Unit,
+    onAnimationsEnabledChange: (Boolean) -> Unit,
 ) {
     val api = remember { GameApi(initialDifficulty) }
     var difficulty by remember { mutableStateOf(initialDifficulty) }
@@ -106,6 +147,7 @@ fun GameScreen(
     val elapsedSeconds = elapsed.inWholeSeconds.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
     var difficultyMenuExpanded by remember { mutableStateOf(false) }
     var showHistoryDialog by remember { mutableStateOf(false) }
+    var showSettingsDialog by remember { mutableStateOf(false) }
     var historyVersion by remember { mutableStateOf(0) }
     var winRecorded by remember { mutableStateOf(false) }
     var celebration by remember { mutableStateOf<NewRecordCelebration?>(null) }
@@ -124,6 +166,7 @@ fun GameScreen(
     }
 
     val statusEmoji = board.status.asStatusEmoji()
+    val soundPlayer = rememberSoundPlayer(soundsEnabled)
 
     GameTimerEffects(board = board, timer = timer)
 
@@ -136,6 +179,7 @@ fun GameScreen(
         onWinRecordedChange = { winRecorded = it },
         onHistoryVersionIncrement = { historyVersion += 1 },
         onCelebrationChange = { celebration = it },
+        soundPlayer = soundPlayer,
     )
 
     AutoDismissCelebration(celebration = celebration) {
@@ -166,6 +210,8 @@ fun GameScreen(
                     elapsedSeconds = elapsedSeconds,
                     statusEmoji = statusEmoji,
                     onHistoryClick = { showHistoryDialog = true },
+                    onSettingsClick = { showSettingsDialog = true },
+                    animationsEnabled = animationsEnabled,
                 )
             },
         ) { innerPadding ->
@@ -209,12 +255,14 @@ fun GameScreen(
                             onReveal = { x, y ->
                                 if (board.status == GameStatus.IN_PROGRESS) {
                                     api.onReveal(x, y)
+                                    soundPlayer.reveal()
                                     refreshBoard()
                                 }
                             },
                             onToggleFlag = { x, y ->
                                 if (board.status == GameStatus.IN_PROGRESS) {
                                     api.onToggleFlag(x, y)
+                                    soundPlayer.click()
                                     refreshBoard()
                                 }
                             },
@@ -226,6 +274,7 @@ fun GameScreen(
                 }
 
                 val celebrationState = celebration
+                val reducedMotionEnabled = LocalReducedMotion.current
                 if (celebrationState != null && !reducedMotionEnabled) {
                     ConfettiOverlay(
                         modifier =
@@ -268,6 +317,16 @@ fun GameScreen(
             onClose = { showHistoryDialog = false },
         )
     }
+
+    if (showSettingsDialog) {
+        SettingsDialog(
+            soundsEnabled = soundsEnabled,
+            animationsEnabled = animationsEnabled,
+            onSoundsEnabledChange = onSoundsEnabledChange,
+            onAnimationsEnabledChange = onAnimationsEnabledChange,
+            onDismissRequest = { showSettingsDialog = false },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -282,6 +341,8 @@ private fun GameTopBar(
     elapsedSeconds: Int,
     statusEmoji: String,
     onHistoryClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+    animationsEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val difficulties = remember { Difficulty.values().toList() }
@@ -308,6 +369,7 @@ private fun GameTopBar(
                 difficulties = difficulties,
                 onSelected = onDifficultySelected,
                 difficulty = difficulty,
+                animationsEnabled = animationsEnabled,
             )
         },
         actions = {
@@ -325,14 +387,50 @@ private fun GameTopBar(
                     )
                 }
 
+                val resetInteraction = remember { MutableInteractionSource() }
                 Button(
                     onClick = onReset,
-                    modifier = Modifier.heightIn(min = 48.dp),
+                    modifier =
+                        Modifier
+                            .heightIn(min = 48.dp)
+                            .pressScale(
+                                interactionSource = resetInteraction,
+                                animationsEnabled = animationsEnabled,
+                                label = "resetPress",
+                            ),
+                    interactionSource = resetInteraction,
                 ) {
                     Text(
                         text = t(Res.string.reset_button),
                         style = MaterialTheme.typography.labelLarge,
                     )
+                }
+
+                var settingsExpanded by remember { mutableStateOf(false) }
+                Box {
+                    IconButton(onClick = { settingsExpanded = true }) {
+                        Text(
+                            text = "⋮",
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = settingsExpanded,
+                        onDismissRequest = { settingsExpanded = false },
+                    ) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    text = t(Res.string.action_settings),
+                                    style = MaterialTheme.typography.bodyLarge,
+                                )
+                            },
+                            onClick = {
+                                settingsExpanded = false
+                                onSettingsClick()
+                            },
+                        )
+                    }
                 }
             }
         },
@@ -354,12 +452,19 @@ private fun DifficultyButton(
     difficulties: List<Difficulty>,
     onSelected: (Difficulty) -> Unit,
     difficulty: Difficulty,
+    animationsEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
+        val interactionSource = remember { MutableInteractionSource() }
         FilledTonalButton(
             onClick = onClick,
-            modifier = Modifier.heightIn(min = 48.dp),
+            modifier =
+                Modifier
+                    .heightIn(min = 48.dp)
+                    .pressScale(interactionSource = interactionSource, animationsEnabled = animationsEnabled, label = "difficultyPress"),
+            interactionSource = interactionSource,
+            contentPadding = ButtonDefaults.ButtonWithIconContentPadding,
         ) {
             Text(
                 text = t(Res.string.difficulty, difficulty.localizedLabel()),
@@ -475,9 +580,11 @@ private fun GameCelebrationEffects(
     onWinRecordedChange: (Boolean) -> Unit,
     onHistoryVersionIncrement: () -> Unit,
     onCelebrationChange: (NewRecordCelebration?) -> Unit,
+    soundPlayer: SoundPlayer,
 ) {
     LaunchedEffect(board.status, historyStore, difficulty) {
         if (board.status == GameStatus.WON && !winRecorded) {
+            soundPlayer.win()
             val elapsedMillis = elapsed.inWholeMilliseconds
             val previousRuns =
                 runCatching { historyStore.getTop10(difficulty) }.getOrElse { emptyList() }
@@ -518,6 +625,7 @@ private fun GameCelebrationEffects(
         }
         if (board.status == GameStatus.LOST) {
             onCelebrationChange(null)
+            soundPlayer.lose()
         }
     }
 }
@@ -592,12 +700,35 @@ private fun CellView(
     boardStatus: GameStatus,
     modifier: Modifier = Modifier,
 ) {
-    val backgroundColor =
+    val reducedMotion = LocalReducedMotion.current
+    val animationEnabled = !reducedMotion
+    val targetBackground =
         when (cell.state) {
             CellState.HIDDEN -> hiddenCellColor()
             CellState.REVEALED -> revealedCellColor()
             CellState.FLAGGED -> flaggedCellColor()
         }
+    val backgroundColor by animateColorAsState(
+        targetValue = targetBackground,
+        animationSpec = if (animationEnabled) tween(durationMillis = 220) else snap(),
+        label = "cellBackground",
+    )
+    val revealScaleRaw by animateFloatAsState(
+        targetValue =
+            when {
+                !animationEnabled -> 1f
+                cell.state == CellState.REVEALED -> 1f
+                else -> 0.95f
+            },
+        animationSpec =
+            if (animationEnabled) {
+                tween(durationMillis = 220, easing = FastOutSlowInEasing)
+            } else {
+                snap()
+            },
+        label = "cellRevealScale",
+    )
+    val revealScale = if (animationEnabled && cell.state == CellState.REVEALED) revealScaleRaw else 1f
     val interactionModifier =
         Modifier.cellInteractions(
             revealEnabled = boardStatus == GameStatus.IN_PROGRESS && cell.state == CellState.HIDDEN,
@@ -609,7 +740,11 @@ private fun CellView(
     CellContainer(
         backgroundColor = backgroundColor,
         cornerRadius = 6.dp,
-        modifier = modifier,
+        modifier =
+            modifier.graphicsLayer {
+                scaleX = revealScale
+                scaleY = revealScale
+            },
         interactionModifier = interactionModifier,
     ) {
         CellContent(
@@ -629,3 +764,26 @@ private fun Difficulty.toStringResource(): StringResource =
 
 @Composable
 private fun Difficulty.localizedLabel(): String = stringResource(toStringResource())
+
+@Composable
+private fun Modifier.pressScale(
+    interactionSource: MutableInteractionSource,
+    animationsEnabled: Boolean,
+    label: String,
+    pressedScale: Float = 0.98f,
+): Modifier {
+    val reducedMotion = LocalReducedMotion.current
+    val shouldAnimate = animationsEnabled && !reducedMotion
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val targetScale = if (isPressed) pressedScale else 1f
+    val animationSpec = if (shouldAnimate) tween<Float>(durationMillis = 120, easing = FastOutSlowInEasing) else snap()
+    val scale by animateFloatAsState(
+        targetValue = if (shouldAnimate) targetScale else 1f,
+        animationSpec = animationSpec,
+        label = label,
+    )
+    return graphicsLayer {
+        scaleX = scale
+        scaleY = scale
+    }
+}

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ReducedMotion.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/ReducedMotion.kt
@@ -1,0 +1,5 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalReducedMotion = staticCompositionLocalOf { false }

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/SettingsDialog.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/SettingsDialog.kt
@@ -1,0 +1,82 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.pekomon.minesweeper.composeapp.generated.resources.Res
+import com.example.pekomon.minesweeper.composeapp.generated.resources.settings_animations
+import com.example.pekomon.minesweeper.composeapp.generated.resources.settings_sounds
+import com.example.pekomon.minesweeper.composeapp.generated.resources.settings_title
+import com.example.pekomon.minesweeper.i18n.t
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun SettingsDialog(
+    soundsEnabled: Boolean,
+    animationsEnabled: Boolean,
+    onSoundsEnabledChange: (Boolean) -> Unit,
+    onAnimationsEnabledChange: (Boolean) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {},
+        title = {
+            Text(
+                text = t(Res.string.settings_title),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SettingsSwitchRow(
+                    label = t(Res.string.settings_sounds),
+                    checked = soundsEnabled,
+                    onCheckedChange = onSoundsEnabledChange,
+                )
+                SettingsSwitchRow(
+                    label = t(Res.string.settings_animations),
+                    checked = animationsEnabled,
+                    onCheckedChange = onAnimationsEnabledChange,
+                )
+            }
+        },
+    )
+}
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun SettingsSwitchRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        },
+        trailingContent = {
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+            )
+        },
+        modifier = Modifier.padding(horizontal = 8.dp),
+    )
+}

--- a/Minesweeper/composeApp/src/commonMain/resources/strings.properties
+++ b/Minesweeper/composeApp/src/commonMain/resources/strings.properties
@@ -1,5 +1,7 @@
 app_name=Minesweeper
 action_settings=Settings
+settings_sounds=Sounds
+settings_animations=Animations
 action_history=History
 difficulty=Difficulty
 difficulty_easy=Easy

--- a/Minesweeper/composeApp/src/commonMain/resources/strings.properties
+++ b/Minesweeper/composeApp/src/commonMain/resources/strings.properties
@@ -1,5 +1,4 @@
 app_name=Minesweeper
-action_settings=Settings
 settings_sounds=Sounds
 settings_animations=Animations
 action_history=History

--- a/Minesweeper/composeApp/src/commonMain/resources/strings_fi.properties
+++ b/Minesweeper/composeApp/src/commonMain/resources/strings_fi.properties
@@ -1,5 +1,4 @@
 app_name=Miinaharava
-action_settings=Asetukset
 action_history=Historia
 difficulty=Vaikeustaso
 difficulty_easy=Helppo

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.ios.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.ios.kt
@@ -2,6 +2,7 @@ package com.example.pekomon.minesweeper.audio
 
 import androidx.compose.runtime.Composable
 
+@Suppress("ForbiddenComment")
 @Composable
 actual fun rememberPlatformSoundPlayer(): SoundPlayer {
     // TODO: Implement using AVFoundation for richer native sounds.

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.ios.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.ios.kt
@@ -1,0 +1,9 @@
+package com.example.pekomon.minesweeper.audio
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun rememberPlatformSoundPlayer(): SoundPlayer {
+    // TODO: Implement using AVFoundation for richer native sounds.
+    return NullSoundPlayer
+}

--- a/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
+++ b/Minesweeper/composeApp/src/iosMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.ios.kt
@@ -15,10 +15,22 @@ private class IosSettingsRepository : SettingsRepository {
         defaults.setObject(value.name, forKey = SettingsKeys.SELECTED_DIFFICULTY)
     }
 
-    override fun isReducedMotionEnabled(): Boolean = defaults.boolForKey(SettingsKeys.REDUCED_MOTION_ENABLED)
+    override fun isSoundEnabled(): Boolean {
+        val value = defaults.objectForKey(SettingsKeys.ENABLE_SOUNDS) as? Boolean
+        return value ?: true
+    }
 
-    override fun setReducedMotionEnabled(enabled: Boolean) {
-        defaults.setBool(enabled, forKey = SettingsKeys.REDUCED_MOTION_ENABLED)
+    override fun setSoundEnabled(enabled: Boolean) {
+        defaults.setBool(enabled, forKey = SettingsKeys.ENABLE_SOUNDS)
+    }
+
+    override fun isAnimationEnabled(): Boolean {
+        val value = defaults.objectForKey(SettingsKeys.ENABLE_ANIMATIONS) as? Boolean
+        return value ?: true
+    }
+
+    override fun setAnimationEnabled(enabled: Boolean) {
+        defaults.setBool(enabled, forKey = SettingsKeys.ENABLE_ANIMATIONS)
     }
 }
 

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.jvm.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.jvm.kt
@@ -2,13 +2,13 @@ package com.example.pekomon.minesweeper.audio
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import javax.sound.sampled.AudioFormat
-import javax.sound.sampled.AudioSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioSystem
 import kotlin.math.PI
 import kotlin.math.roundToInt
 import kotlin.math.sin
@@ -39,7 +39,11 @@ private class JvmSoundPlayer : SoundPlayer {
         playTone(frequencyHz = 320, durationMs = 360)
     }
 
-    private fun playTone(frequencyHz: Int, durationMs: Int, delayBeforeMs: Long = 0L) {
+    private fun playTone(
+        frequencyHz: Int,
+        durationMs: Int,
+        delayBeforeMs: Long = 0L,
+    ) {
         scope.launch {
             if (delayBeforeMs > 0) {
                 delay(delayBeforeMs)
@@ -59,7 +63,10 @@ private class JvmSoundPlayer : SoundPlayer {
         }
     }
 
-    private suspend fun playToneInternal(frequencyHz: Int, durationMs: Int) {
+    private suspend fun playToneInternal(
+        frequencyHz: Int,
+        durationMs: Int,
+    ) {
         val clip = runCatching { AudioSystem.getClip() }.getOrNull() ?: return
         try {
             val data = generateTone(frequencyHz, durationMs)
@@ -81,7 +88,10 @@ private data class ToneSpec(
     val delayBeforeMs: Long,
 )
 
-fun generateTone(frequencyHz: Int, millis: Int): ByteArray {
+fun generateTone(
+    frequencyHz: Int,
+    millis: Int,
+): ByteArray {
     val totalSamples = (SAMPLE_RATE * (millis / 1000.0)).roundToInt().coerceAtLeast(1)
     val buffer = ByteArray(totalSamples * 2)
     for (i in 0 until totalSamples) {

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.jvm.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.jvm.kt
@@ -1,0 +1,97 @@
+package com.example.pekomon.minesweeper.audio
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioSystem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.math.PI
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+private const val SAMPLE_RATE = 44_100
+private val AUDIO_FORMAT = AudioFormat(SAMPLE_RATE.toFloat(), 16, 1, true, false)
+
+private class JvmSoundPlayer : SoundPlayer {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    override fun click() {
+        playTone(frequencyHz = 420, durationMs = 80)
+    }
+
+    override fun reveal() {
+        playTone(frequencyHz = 620, durationMs = 100)
+    }
+
+    override fun win() {
+        playSequence(
+            ToneSpec(frequencyHz = 660, durationMs = 120, delayBeforeMs = 0),
+            ToneSpec(frequencyHz = 880, durationMs = 130, delayBeforeMs = 120),
+            ToneSpec(frequencyHz = 1040, durationMs = 160, delayBeforeMs = 140),
+        )
+    }
+
+    override fun lose() {
+        playTone(frequencyHz = 320, durationMs = 360)
+    }
+
+    private fun playTone(frequencyHz: Int, durationMs: Int, delayBeforeMs: Long = 0L) {
+        scope.launch {
+            if (delayBeforeMs > 0) {
+                delay(delayBeforeMs)
+            }
+            playToneInternal(frequencyHz, durationMs)
+        }
+    }
+
+    private fun playSequence(vararg tones: ToneSpec) {
+        scope.launch {
+            tones.forEachIndexed { index, tone ->
+                if (tone.delayBeforeMs > 0 && index != 0) {
+                    delay(tone.delayBeforeMs)
+                }
+                playToneInternal(tone.frequencyHz, tone.durationMs)
+            }
+        }
+    }
+
+    private suspend fun playToneInternal(frequencyHz: Int, durationMs: Int) {
+        val clip = runCatching { AudioSystem.getClip() }.getOrNull() ?: return
+        try {
+            val data = generateTone(frequencyHz, durationMs)
+            clip.open(AUDIO_FORMAT, data, 0, data.size)
+            clip.start()
+            delay(durationMs.toLong())
+        } catch (_: Exception) {
+            // Ignore playback failures on desktop
+        } finally {
+            runCatching { clip.stop() }
+            runCatching { clip.close() }
+        }
+    }
+}
+
+private data class ToneSpec(
+    val frequencyHz: Int,
+    val durationMs: Int,
+    val delayBeforeMs: Long,
+)
+
+fun generateTone(frequencyHz: Int, millis: Int): ByteArray {
+    val totalSamples = (SAMPLE_RATE * (millis / 1000.0)).roundToInt().coerceAtLeast(1)
+    val buffer = ByteArray(totalSamples * 2)
+    for (i in 0 until totalSamples) {
+        val angle = 2.0 * PI * i * frequencyHz / SAMPLE_RATE
+        val amplitude = (sin(angle) * Short.MAX_VALUE).toInt()
+        buffer[i * 2] = (amplitude and 0xFF).toByte()
+        buffer[i * 2 + 1] = ((amplitude shr 8) and 0xFF).toByte()
+    }
+    return buffer
+}
+
+@Composable
+actual fun rememberPlatformSoundPlayer(): SoundPlayer = remember { JvmSoundPlayer() }

--- a/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
+++ b/Minesweeper/composeApp/src/jvmMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.jvm.kt
@@ -15,10 +15,16 @@ internal class JvmSettingsRepository(
         preferences.put(SettingsKeys.SELECTED_DIFFICULTY, value.name)
     }
 
-    override fun isReducedMotionEnabled(): Boolean = preferences.getBoolean(SettingsKeys.REDUCED_MOTION_ENABLED, false)
+    override fun isSoundEnabled(): Boolean = preferences.getBoolean(SettingsKeys.ENABLE_SOUNDS, true)
 
-    override fun setReducedMotionEnabled(enabled: Boolean) {
-        preferences.putBoolean(SettingsKeys.REDUCED_MOTION_ENABLED, enabled)
+    override fun setSoundEnabled(enabled: Boolean) {
+        preferences.putBoolean(SettingsKeys.ENABLE_SOUNDS, enabled)
+    }
+
+    override fun isAnimationEnabled(): Boolean = preferences.getBoolean(SettingsKeys.ENABLE_ANIMATIONS, true)
+
+    override fun setAnimationEnabled(enabled: Boolean) {
+        preferences.putBoolean(SettingsKeys.ENABLE_ANIMATIONS, enabled)
     }
 }
 

--- a/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/JvmSettingsRepositoryTest.kt
+++ b/Minesweeper/composeApp/src/jvmTest/kotlin/com/example/pekomon/minesweeper/settings/JvmSettingsRepositoryTest.kt
@@ -40,11 +40,20 @@ class JvmSettingsRepositoryTest {
     }
 
     @Test
-    fun `round trips reduced motion`() {
-        assertEquals(false, repository.isReducedMotionEnabled())
+    fun `round trips sound preference`() {
+        assertEquals(true, repository.isSoundEnabled())
 
-        repository.setReducedMotionEnabled(true)
+        repository.setSoundEnabled(false)
 
-        assertEquals(true, repository.isReducedMotionEnabled())
+        assertEquals(false, repository.isSoundEnabled())
+    }
+
+    @Test
+    fun `round trips animation preference`() {
+        assertEquals(true, repository.isAnimationEnabled())
+
+        repository.setAnimationEnabled(false)
+
+        assertEquals(false, repository.isAnimationEnabled())
     }
 }

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.wasmJs.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.wasmJs.kt
@@ -2,6 +2,7 @@ package com.example.pekomon.minesweeper.audio
 
 import androidx.compose.runtime.Composable
 
+@Suppress("ForbiddenComment")
 @Composable
 actual fun rememberPlatformSoundPlayer(): SoundPlayer {
     // TODO: Implement using Web Audio API via JavaScript interop when available.

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.wasmJs.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/audio/SoundPlayer.wasmJs.kt
@@ -1,0 +1,9 @@
+package com.example.pekomon.minesweeper.audio
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun rememberPlatformSoundPlayer(): SoundPlayer {
+    // TODO: Implement using Web Audio API via JavaScript interop when available.
+    return NullSoundPlayer
+}

--- a/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
+++ b/Minesweeper/composeApp/src/wasmJsMain/kotlin/com/example/pekomon/minesweeper/settings/SettingsProvider.wasmJs.kt
@@ -15,14 +15,24 @@ private class WasmSettingsRepository : SettingsRepository {
         storage.setItem(SettingsKeys.SELECTED_DIFFICULTY, value.name)
     }
 
-    override fun isReducedMotionEnabled(): Boolean =
+    override fun isSoundEnabled(): Boolean =
         storage
-            .getItem(SettingsKeys.REDUCED_MOTION_ENABLED)
+            .getItem(SettingsKeys.ENABLE_SOUNDS)
             ?.toBoolean()
-            ?: false
+            ?: true
 
-    override fun setReducedMotionEnabled(enabled: Boolean) {
-        storage.setItem(SettingsKeys.REDUCED_MOTION_ENABLED, enabled.toString())
+    override fun setSoundEnabled(enabled: Boolean) {
+        storage.setItem(SettingsKeys.ENABLE_SOUNDS, enabled.toString())
+    }
+
+    override fun isAnimationEnabled(): Boolean =
+        storage
+            .getItem(SettingsKeys.ENABLE_ANIMATIONS)
+            ?.toBoolean()
+            ?: true
+
+    override fun setAnimationEnabled(enabled: Boolean) {
+        storage.setItem(SettingsKeys.ENABLE_ANIMATIONS, enabled.toString())
     }
 }
 


### PR DESCRIPTION
## Summary
- add persisted toggles for sounds/animations with a new settings dialog wired into the existing repository
- implement reduced-motion-aware reveal/flag/button animations and expose a LocalReducedMotion flag
- generate synthetic sound effects (ToneGenerator on Android, sine-wave clips on desktop; iOS/wasm remain no-ops) and trigger them for gameplay feedback

## Testing
- composeApp:jvmTest *(fails: Maven repositories return HTTP 403 in CI sandbox)*

Reduced motion support is driven by disabling animations, and synthetic SFX currently cover Android/Desktop while iOS/wasm remain silent stubs.

fixes #49
closes #49

------
https://chatgpt.com/codex/tasks/task_b_68e2523e383c832fb3df20f17aaea579