### PR TITLE
Fix invalid Spotless patch artifact path

### DIFF
--- a/.github/workflows/minesweeper-ci.yml
+++ b/.github/workflows/minesweeper-ci.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Generate Spotless patch
         if: always() && steps.spotless_check.outcome == 'failure'
         run: |
-          cd ..
           if git diff --quiet; then
             echo "No changes from spotlessApply."
           else
@@ -107,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: spotless-patch
-          path: ../spotless.patch
+          path: spotless.patch
           if-no-files-found: ignore
 
   tests:


### PR DESCRIPTION
## Summary
- ensure the Spotless patch is generated within the Minesweeper working directory
- update the artifact upload path to reference the local spotless patch file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e271a97a08832fab73ab3a04bb2f03