### PR TITLE
UI tests: Compose instrumented (no Robolectric) + screenshots on CI emulator

### DIFF
--- a/.github/workflows/minesweeper-ci.yml
+++ b/.github/workflows/minesweeper-ci.yml
@@ -148,6 +148,56 @@ jobs:
             Minesweeper/composeApp/build/reports/kover/xml
           if-no-files-found: warn
 
+  android-ui-tests:
+    name: Android (instrumented UI tests)
+    needs: [tests]
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.minesweeper == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Minesweeper
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref }}
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install Android SDK (accept licenses)
+        uses: android-actions/setup-android@v3
+
+      - name: Gradle build cache
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run UI tests on emulator (API 34)
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: default
+          disable-animations: true
+          script: |
+            cd Minesweeper
+            ./gradlew :composeApp:connectedDebugAndroidTest
+            mkdir -p composeApp/build/outputs/androidTest-screenshots
+            adb pull /sdcard/Android/data/com.example.pekomon.minesweeper/files/androidTest-screenshots composeApp/build/outputs/androidTest-screenshots || true
+
+      - name: Upload UI test screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-screenshots
+          path: Minesweeper/composeApp/build/outputs/androidTest-screenshots/**
+          if-no-files-found: warn
+
   android:
     name: Android (assembleDebug)
     needs: [tests]

--- a/Minesweeper/composeApp/build.gradle.kts
+++ b/Minesweeper/composeApp/build.gradle.kts
@@ -79,6 +79,22 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
+        val androidInstrumentedTest by getting {
+            kotlin.srcDir("src/androidAndroidTest/kotlin")
+            dependencies {
+                implementation(
+                    project.dependencies.platform(
+                        libs.androidx.compose.bom
+                            .get(),
+                    ),
+                )
+                implementation(libs.androidx.compose.ui.test.junit4)
+                implementation(libs.androidx.test.core)
+                implementation(libs.androidx.testExt.junit)
+                implementation(libs.androidx.test.rules)
+                implementation(libs.androidx.test.runner)
+            }
+        }
         val jvmMain by getting {
             dependencies {
                 implementation(compose.desktop.currentOs)
@@ -111,6 +127,7 @@ android {
                 .toInt()
         versionCode = 1
         versionName = "1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     packaging {
         resources {

--- a/Minesweeper/composeApp/src/androidAndroidTest/kotlin/com/example/pekomon/minesweeper/ui/GameBasicFlowsTest.kt
+++ b/Minesweeper/composeApp/src/androidAndroidTest/kotlin/com/example/pekomon/minesweeper/ui/GameBasicFlowsTest.kt
@@ -1,0 +1,72 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasAnyDescendant
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.longClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.pekomon.minesweeper.MainActivity
+import com.example.pekomon.minesweeper.game.Difficulty
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GameBasicFlowsTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        composeRule.setDifficulty(Difficulty.EASY)
+    }
+
+    @Test
+    fun revealCellChangesAppearance() {
+        val result = composeRule.revealSafeCell()
+
+        assertNotEquals(result.before.centerPixel(), result.after.centerPixel())
+    }
+
+    @Test
+    fun flagCellShowsFlagEmoji() {
+        val cellTag = TestTags.cell(0, 0)
+
+        composeRule.onNodeWithTag(cellTag, useUnmergedTree = true)
+            .performTouchInput { longClick() }
+
+        composeRule.onNodeWithTag(cellTag, useUnmergedTree = true)
+            .assert(hasAnyDescendant(hasText("🚩")))
+    }
+
+    @Test
+    fun resetClearsBoard() {
+        val result = composeRule.revealSafeCell()
+
+        composeRule.resetGame(Difficulty.EASY.width * Difficulty.EASY.height)
+
+        val afterReset =
+            composeRule.onNodeWithTag(result.tag, useUnmergedTree = true).captureToImage()
+
+        assertEquals(result.before.centerPixel(), afterReset.centerPixel())
+    }
+
+    @Test
+    fun changeDifficultyUpdatesGridSize() {
+        val easyCount = composeRule.cellCount()
+        assertEquals(Difficulty.EASY.width * Difficulty.EASY.height, easyCount)
+
+        composeRule.setDifficulty(Difficulty.MEDIUM)
+
+        val mediumCount = composeRule.cellCount()
+        assertEquals(Difficulty.MEDIUM.width * Difficulty.MEDIUM.height, mediumCount)
+    }
+}

--- a/Minesweeper/composeApp/src/androidAndroidTest/kotlin/com/example/pekomon/minesweeper/ui/TestHelpers.kt
+++ b/Minesweeper/composeApp/src/androidAndroidTest/kotlin/com/example/pekomon/minesweeper/ui/TestHelpers.kt
@@ -1,0 +1,111 @@
+package com.example.pekomon.minesweeper.ui
+
+import android.graphics.Bitmap
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.semantics.SemanticsMatcher
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.compose.ui.test.onAllNodes
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.useUnmergedTree
+import androidx.compose.ui.test.waitForIdle
+import androidx.compose.ui.test.waitUntil
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.pekomon.minesweeper.game.Difficulty
+import java.io.File
+
+internal data class RevealResult(
+    val tag: String,
+    val before: ImageBitmap,
+    val after: ImageBitmap,
+)
+
+private const val CELL_TAG_PREFIX = "cell-"
+
+private val easyCellCount = Difficulty.EASY.width * Difficulty.EASY.height
+private val easyRows = Difficulty.EASY.height
+private val easyCols = Difficulty.EASY.width
+
+internal fun AndroidComposeTestRule<*, *>.waitForBoard(expectedCells: Int = easyCellCount) {
+    waitUntil(timeoutMillis = 5_000) { cellCount() == expectedCells }
+    waitForIdle()
+}
+
+internal fun AndroidComposeTestRule<*, *>.cellCount(): Int =
+    onAllNodes(hasTestTagPrefix(CELL_TAG_PREFIX), useUnmergedTree = true).fetchSemanticsNodes().size
+
+internal fun AndroidComposeTestRule<*, *>.setDifficulty(difficulty: Difficulty) {
+    onNodeWithTag(TestTags.BTN_DIFFICULTY, useUnmergedTree = true).performClick()
+    onNodeWithText(difficultyLabel(difficulty), useUnmergedTree = true).performClick()
+    waitForBoard(difficulty.width * difficulty.height)
+}
+
+internal fun AndroidComposeTestRule<*, *>.revealSafeCell(): RevealResult {
+    waitForBoard()
+    for (row in 0 until easyRows) {
+        for (col in 0 until easyCols) {
+            val tag = TestTags.cell(row, col)
+            val node = onNodeWithTag(tag, useUnmergedTree = true)
+            val before = node.captureToImage()
+            node.performClick()
+            waitForIdle()
+            if (!isGameLost()) {
+                val after = onNodeWithTag(tag, useUnmergedTree = true).captureToImage()
+                return RevealResult(tag, before, after)
+            }
+            resetGame()
+        }
+    }
+    error("Failed to reveal a safe cell")
+}
+
+internal fun AndroidComposeTestRule<*, *>.resetGame(expectedCells: Int = easyCellCount) {
+    onNodeWithTag(TestTags.BTN_RESET, useUnmergedTree = true).performClick()
+    waitForIdle()
+    waitForBoard(expectedCells)
+    waitUntil(timeoutMillis = 5_000) { !isGameLost() && getTimerText().contains("0s") }
+}
+
+internal fun AndroidComposeTestRule<*, *>.getTimerText(): String {
+    val node = onNodeWithTag(TestTags.TXT_TIMER, useUnmergedTree = true)
+    val semantics = node.fetchSemanticsNode().config
+    val text = semantics.getOrNull(SemanticsProperties.Text) ?: return ""
+    return text.joinToString(separator = "") { it.text }
+}
+
+internal fun AndroidComposeTestRule<*, *>.isGameLost(): Boolean = getTimerText().contains("💥")
+
+internal fun AndroidComposeTestRule<*, *>.saveScreenshot(image: ImageBitmap, fileName: String): File {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val context = instrumentation.targetContext
+    val outputDir = File(context.getExternalFilesDir(null), "androidTest-screenshots").apply { mkdirs() }
+    val outputFile = File(outputDir, fileName)
+    outputFile.outputStream().use { stream ->
+        image.asAndroidBitmap().compress(Bitmap.CompressFormat.PNG, 100, stream)
+    }
+    return outputFile
+}
+
+internal fun hasTestTagPrefix(prefix: String): SemanticsMatcher =
+    SemanticsMatcher("TestTag starts with $prefix") { semanticsNode ->
+        val tag = semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
+        tag?.startsWith(prefix) == true
+    }
+
+internal fun ImageBitmap.centerPixel(): Int {
+    val pixels = toPixelMap()
+    return pixels[pixels.width / 2, pixels.height / 2]
+}
+
+private fun difficultyLabel(difficulty: Difficulty): String =
+    when (difficulty) {
+        Difficulty.EASY -> "Easy"
+        Difficulty.MEDIUM -> "Medium"
+        Difficulty.HARD -> "Hard"
+    }

--- a/Minesweeper/composeApp/src/androidAndroidTest/kotlin/com/example/pekomon/minesweeper/ui/TimerAndScreenshotTest.kt
+++ b/Minesweeper/composeApp/src/androidAndroidTest/kotlin/com/example/pekomon/minesweeper/ui/TimerAndScreenshotTest.kt
@@ -1,0 +1,47 @@
+package com.example.pekomon.minesweeper.ui
+
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.pekomon.minesweeper.MainActivity
+import com.example.pekomon.minesweeper.game.Difficulty
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TimerAndScreenshotTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        composeRule.setDifficulty(Difficulty.EASY)
+    }
+
+    @Test
+    fun timerAdvancesAndScreenshotSaved() {
+        composeRule.revealSafeCell()
+
+        composeRule.mainClock.autoAdvance = false
+        try {
+            composeRule.mainClock.advanceTimeBy(1_200)
+            composeRule.waitForIdle()
+        } finally {
+            composeRule.mainClock.autoAdvance = true
+        }
+
+        val timerText = composeRule.getTimerText()
+        assertTrue("Timer should advance past 1s", timerText.contains("1s") || timerText.contains("2s"))
+
+        val rootImage =
+            composeRule.onNodeWithTag(TestTags.ROOT, useUnmergedTree = true).captureToImage()
+        val screenshot = composeRule.saveScreenshot(rootImage, "game_basic.png")
+
+        assertTrue("Screenshot file must exist", screenshot.exists())
+    }
+}

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/GameScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Dp.Companion.Infinity
 import androidx.compose.ui.unit.Dp.Companion.Unspecified
@@ -194,7 +195,10 @@ private fun GameScreenContent(
         color = MaterialTheme.colorScheme.surface,
     ) {
         Scaffold(
-            modifier = Modifier.fillMaxSize(),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .testTag(TestTags.ROOT),
             contentWindowInsets = WindowInsets.safeDrawing,
             topBar = {
                 GameTopBar(
@@ -360,6 +364,7 @@ private fun GameTopBar(
             Text(
                 text = t(Res.string.timer_label, statusEmoji, elapsedSeconds),
                 style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.testTag(TestTags.TXT_TIMER),
             )
         },
         navigationIcon = {
@@ -380,7 +385,10 @@ private fun GameTopBar(
             ) {
                 OutlinedButton(
                     onClick = onHistoryClick,
-                    modifier = Modifier.heightIn(min = 48.dp),
+                    modifier =
+                        Modifier
+                            .testTag(TestTags.BTN_HISTORY)
+                            .heightIn(min = 48.dp),
                 ) {
                     Text(
                         text = t(Res.string.history_button),
@@ -393,6 +401,7 @@ private fun GameTopBar(
                     onClick = onReset,
                     modifier =
                         Modifier
+                            .testTag(TestTags.BTN_RESET)
                             .heightIn(min = 48.dp)
                             .pressScale(
                                 interactionSource = resetInteraction,
@@ -462,6 +471,7 @@ private fun DifficultyButton(
             onClick = onClick,
             modifier =
                 Modifier
+                    .testTag(TestTags.BTN_DIFFICULTY)
                     .heightIn(min = 48.dp)
                     .pressScale(
                         interactionSource = interactionSource,
@@ -746,10 +756,12 @@ private fun CellView(
         backgroundColor = backgroundColor,
         cornerRadius = 6.dp,
         modifier =
-            modifier.graphicsLayer {
-                scaleX = revealScale
-                scaleY = revealScale
-            },
+            modifier
+                .testTag(TestTags.cell(cell.y, cell.x))
+                .graphicsLayer {
+                    scaleX = revealScale
+                    scaleY = revealScale
+                },
         interactionModifier = interactionModifier,
     ) {
         CellContent(

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/HistoryDialog.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/HistoryDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.example.pekomon.minesweeper.composeapp.generated.resources.Res
 import com.example.pekomon.minesweeper.composeapp.generated.resources.difficulty_easy
@@ -60,6 +61,7 @@ fun HistoryDialog(
 
     AlertDialog(
         onDismissRequest = onClose,
+        modifier = Modifier.testTag(TestTags.DIALOG_HISTORY),
         confirmButton = {
             TextButton(onClick = onClose) {
                 Text(

--- a/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/TestTags.kt
+++ b/Minesweeper/composeApp/src/commonMain/kotlin/com/example/pekomon/minesweeper/ui/TestTags.kt
@@ -1,0 +1,12 @@
+package com.example.pekomon.minesweeper.ui
+
+object TestTags {
+    const val ROOT = "root-scaffold"
+    const val BTN_DIFFICULTY = "btn-difficulty"
+    const val BTN_RESET = "btn-reset"
+    const val TXT_TIMER = "txt-timer"
+    const val TXT_MINES = "txt-mines"
+    fun cell(row: Int, col: Int) = "cell-$row-$col"
+    const val BTN_HISTORY = "btn-history"
+    const val DIALOG_HISTORY = "dialog-history"
+}

--- a/Minesweeper/gradle/libs.versions.toml
+++ b/Minesweeper/gradle/libs.versions.toml
@@ -10,7 +10,10 @@ androidx-core-splashscreen = "1.0.1"
 androidx-datastore = "1.1.1"
 androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.3"
-androidx-testExt = "1.3.0"
+androidx-test-core = "1.6.1"
+androidx-test-ext = "1.2.1"
+androidx-test-rules = "1.6.1"
+androidx-test-runner = "1.6.1"
 compose-bom = "2024.10.01"
 composeHotReload = "1.0.0-beta06"
 composeMultiplatform = "1.8.2"
@@ -30,7 +33,11 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin_test" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
-androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
+androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-rules" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }


### PR DESCRIPTION
## Summary
- add Compose instrumentation UI tests covering basic gameplay flows and screenshot capture helpers
- expose shared test tags across the Minesweeper UI and wire android instrumented test dependencies
- configure CI to run :composeApp:connectedDebugAndroidTest on an emulator and publish captured screenshots

## Testing
- Not run (emulator required in CI)
- ./gradlew :composeApp:spotlessCheck *(fails: upstream Maven 403 while resolving ktlint)*

### How to run locally
- `./gradlew :composeApp:connectedDebugAndroidTest`

### Screenshot output
- `composeApp/build/outputs/androidTest-screenshots/` (also uploaded as `ui-test-screenshots` in CI)

### Test tags
- `root-scaffold`, `btn-difficulty`, `btn-reset`, `txt-timer`, `txt-mines`, `btn-history`, `dialog-history`, `cell-<row>-<col>`

------
https://chatgpt.com/codex/tasks/task_b_68e3da163010832fb3c98605f01dbf79